### PR TITLE
Implement macOS menu bar UI with overlay and settings

### DIFF
--- a/InteractiveClassroom/ContentView.swift
+++ b/InteractiveClassroom/ContentView.swift
@@ -6,55 +6,27 @@
 //
 
 import SwiftUI
-import SwiftData
 
+/// Root view used on iOS/iPadOS to select and present the desired role.
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
+    @State private var selectedRole: UserRole? = nil
 
     var body: some View {
-        NavigationSplitView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
-                    }
+        Group {
+            if let role = selectedRole {
+                switch role {
+                case .screen:
+                    Text("Screen mode is available on macOS menu bar.")
+                        .padding()
+                case .teacher:
+                    Text("Teacher view placeholder")
+                        .padding()
+                case .student:
+                    Text("Student view placeholder")
+                        .padding()
                 }
-                .onDelete(perform: deleteItems)
-            }
-#if os(macOS)
-            .navigationSplitViewColumnWidth(min: 180, ideal: 200)
-#endif
-            .toolbar {
-#if os(iOS)
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
-#endif
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
-                }
-            }
-        } detail: {
-            Text("Select an item")
-        }
-    }
-
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
+            } else {
+                IdentitySelectionView(selection: $selectedRole)
             }
         }
     }
@@ -62,5 +34,4 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
 }

--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -6,27 +6,26 @@
 //
 
 import SwiftUI
-import SwiftData
 
 @main
 struct InteractiveClassroomApp: App {
-    var sharedModelContainer: ModelContainer = {
-        let schema = Schema([
-            Item.self,
-        ])
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-
-        do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
-        } catch {
-            fatalError("Could not create ModelContainer: \(error)")
-        }
-    }()
-
     var body: some Scene {
+#if os(macOS)
+        MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
+            MenuBarView()
+        }
+        Settings {
+            SettingsView()
+        }
+        WindowGroup(id: "ScreenOverlay") {
+            ScreenOverlayView()
+        }
+        .windowStyle(.hiddenTitleBar)
+        .defaultSize(width: 800, height: 600)
+#else
         WindowGroup {
             ContentView()
         }
-        .modelContainer(sharedModelContainer)
+#endif
     }
 }

--- a/InteractiveClassroom/Model/UserRole.swift
+++ b/InteractiveClassroom/Model/UserRole.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Represents the identity a user can choose when entering the app.
+/// Screen is available on macOS while Teacher and Student are intended for iOS/iPadOS.
+public enum UserRole: String, CaseIterable, Identifiable {
+    case screen
+    case teacher
+    case student
+
+    public var id: String { rawValue }
+}

--- a/InteractiveClassroom/View/IdentitySelectionView.swift
+++ b/InteractiveClassroom/View/IdentitySelectionView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Initial view that lets the user choose the role.
+/// The available roles depend on the platform the app is running on.
+struct IdentitySelectionView: View {
+    @Binding var selection: UserRole?
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Select Your Role")
+                .font(.title2)
+                .padding(.bottom, 8)
+#if os(macOS)
+            Button("Screen") { selection = .screen }
+                .buttonStyle(.borderedProminent)
+            Button("Teacher (iOS only)") {}
+                .disabled(true)
+            Button("Student (iOS only)") {}
+                .disabled(true)
+#else
+            Button("Screen (macOS only)") {}
+                .disabled(true)
+            Button("Teacher") { selection = .teacher }
+                .buttonStyle(.borderedProminent)
+            Button("Student") { selection = .student }
+                .buttonStyle(.borderedProminent)
+#endif
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    IdentitySelectionView(selection: .constant(nil))
+}

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -11,7 +11,11 @@ struct MenuBarView: View {
             openWindow(id: "ScreenOverlay")
         }
         Button("Settings") {
-            NSApp.sendAction(#selector(NSApplication.showPreferencesWindow(_:)), to: nil, from: nil)
+            if #available(macOS 13, *) {
+                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            } else {
+                NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+            }
         }
         Divider()
         Button("Quit") {

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -1,0 +1,22 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+/// Content displayed in the menu bar extra for macOS builds.
+struct MenuBarView: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("Show Screen") {
+            openWindow(id: "ScreenOverlay")
+        }
+        Button("Settings") {
+            NSApp.sendAction(#selector(NSApplication.showPreferencesWindow(_:)), to: nil, from: nil)
+        }
+        Divider()
+        Button("Quit") {
+            NSApp.terminate(nil)
+        }
+    }
+}
+#endif

--- a/InteractiveClassroom/View/MacOS/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/ScreenOverlayView.swift
@@ -1,0 +1,20 @@
+#if os(macOS)
+import SwiftUI
+
+/// Placeholder overlay shown on the big screen during a quiz session.
+struct ScreenOverlayView: View {
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.8)
+                .ignoresSafeArea()
+            VStack(spacing: 20) {
+                Text("Screen Overlay Placeholder")
+                    .font(.title)
+                    .foregroundStyle(.white)
+                Text("Statistics and questions will appear here")
+                    .foregroundStyle(.white)
+            }
+        }
+    }
+}
+#endif

--- a/InteractiveClassroom/View/MacOS/SettingsView.swift
+++ b/InteractiveClassroom/View/MacOS/SettingsView.swift
@@ -1,0 +1,35 @@
+#if os(macOS)
+import SwiftUI
+
+/// Settings used to configure how questions are presented and scored.
+struct SettingsView: View {
+    @State private var timeLimit: Int = 60
+    @State private var correctAnswer: String = ""
+    @State private var anonymous: Bool = false
+    @State private var shuffleOptions: Bool = false
+    @State private var allowModification: Bool = true
+    @State private var score: Int = 1
+
+    var body: some View {
+        Form {
+            Section("Question") {
+                Stepper(value: $timeLimit, in: 10...3600, step: 10) {
+                    Text("Time Limit: \(timeLimit) s")
+                }
+                TextField("Correct Answer", text: $correctAnswer)
+                Toggle("Anonymous", isOn: $anonymous)
+                Toggle("Shuffle Options", isOn: $shuffleOptions)
+                Toggle("Allow Answer Changes", isOn: $allowModification)
+                Stepper(value: $score, in: 1...100) {
+                    Text("Score: \(score)")
+                }
+            }
+            Section("Export") {
+                Button("Export Results") {}
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 400, minHeight: 300)
+    }
+}
+#endif

--- a/InteractiveClassroom/View/MacOS/XXView.swift
+++ b/InteractiveClassroom/View/MacOS/XXView.swift
@@ -1,7 +1,0 @@
-//
-//  XXView.swift
-//  InteractiveClassroom
-//
-//  Created by zhb on 2025/8/12.
-//
-


### PR DESCRIPTION
## Summary
- Add cross-platform identity selection and user role model
- Implement macOS menu bar app with big-screen overlay placeholder
- Include configurable settings form for question timing, answers, and scoring

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme InteractiveClassroom -sdk macosx -destination 'platform=macOS' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b05a93e248321841e1af90b7810b9