### PR TITLE
Add peer connection handshake for iOS and macOS

### DIFF
--- a/InteractiveClassroom/ContentView.swift
+++ b/InteractiveClassroom/ContentView.swift
@@ -7,7 +7,8 @@
 
 import SwiftUI
 
-/// Root view used on iOS/iPadOS to select and present the desired role.
+#if os(iOS)
+/// Root view used on iOS and iPadOS to select and present the desired role.
 struct ContentView: View {
     @State private var selectedRole: UserRole? = nil
 
@@ -19,11 +20,13 @@ struct ContentView: View {
                     Text("Screen mode is available on macOS menu bar.")
                         .padding()
                 case .teacher:
-                    Text("Teacher view placeholder")
-                        .padding()
+                    NavigationStack {
+                        ServerConnectView()
+                    }
                 case .student:
-                    Text("Student view placeholder")
-                        .padding()
+                    NavigationStack {
+                        ServerConnectView()
+                    }
                 }
             } else {
                 IdentitySelectionView(selection: $selectedRole)
@@ -35,3 +38,4 @@ struct ContentView: View {
 #Preview {
     ContentView()
 }
+#endif

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -1,0 +1,113 @@
+import Foundation
+import MultipeerConnectivity
+#if canImport(UIKit)
+import UIKit
+#endif
+
+@MainActor
+final class PeerConnectionManager: NSObject, ObservableObject {
+    private let serviceType = "iclassrm"
+    private let myPeerID: MCPeerID
+    private var session: MCSession
+    private var advertiser: MCNearbyServiceAdvertiser?
+    private var browser: MCNearbyServiceBrowser?
+
+    @Published var availablePeers: [MCPeerID] = []
+    @Published var connectionStatus: String = "Not Connected"
+    @Published var hostCode: String?
+
+    override init() {
+#if os(macOS)
+        myPeerID = MCPeerID(displayName: Host.current().localizedName ?? "macOS")
+#else
+        myPeerID = MCPeerID(displayName: UIDevice.current.name)
+#endif
+        session = MCSession(peer: myPeerID, securityIdentity: nil, encryptionPreference: .required)
+        super.init()
+        session.delegate = self
+    }
+
+    func startHosting() {
+        hostCode = String(format: "%06d", Int.random(in: 0..<1_000_000))
+        advertiser = MCNearbyServiceAdvertiser(peer: myPeerID, discoveryInfo: nil, serviceType: serviceType)
+        advertiser?.delegate = self
+        advertiser?.startAdvertisingPeer()
+        connectionStatus = "Awaiting connection..."
+    }
+
+    func startBrowsing() {
+        browser = MCNearbyServiceBrowser(peer: myPeerID, serviceType: serviceType)
+        browser?.delegate = self
+        browser?.startBrowsingForPeers()
+    }
+
+    func stopBrowsing() {
+        browser?.stopBrowsingForPeers()
+        browser = nil
+        availablePeers.removeAll()
+    }
+
+    func connect(to peer: MCPeerID, passcode: String) {
+        let context = passcode.data(using: .utf8)
+        browser?.invitePeer(peer, to: session, withContext: context, timeout: 30)
+    }
+}
+
+extension PeerConnectionManager: MCNearbyServiceAdvertiserDelegate {
+    nonisolated func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+        let code = context.flatMap { String(data: $0, encoding: .utf8) }
+        Task { @MainActor in
+            if code == self.hostCode {
+                invitationHandler(true, self.session)
+            } else {
+                invitationHandler(false, nil)
+            }
+        }
+    }
+}
+
+extension PeerConnectionManager: MCNearbyServiceBrowserDelegate {
+    nonisolated func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) {
+        Task { @MainActor in
+            if !self.availablePeers.contains(peerID) {
+                self.availablePeers.append(peerID)
+            }
+        }
+    }
+
+    nonisolated func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        Task { @MainActor in
+            self.availablePeers.removeAll { $0 == peerID }
+        }
+    }
+}
+
+extension PeerConnectionManager: MCSessionDelegate {
+    nonisolated func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        Task { @MainActor in
+            switch state {
+            case .connected:
+                self.connectionStatus = "Connected to \(peerID.displayName)"
+            case .connecting:
+                self.connectionStatus = "Connecting to \(peerID.displayName)..."
+            case .notConnected:
+                self.connectionStatus = "Not Connected"
+            @unknown default:
+                self.connectionStatus = "Unknown State"
+            }
+        }
+    }
+
+    nonisolated func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {}
+    nonisolated func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {}
+    nonisolated func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {}
+    nonisolated func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {}
+    nonisolated func session(_ session: MCSession, didReceiveCertificate certificate: [Any]?, fromPeer peerID: MCPeerID, certificateHandler: @escaping (Bool) -> Void) {
+        certificateHandler(true)
+    }
+}
+
+extension MCPeerID: Identifiable {
+    public var id: String { displayName }
+}
+

--- a/InteractiveClassroom/View/MacOS/SettingsView.swift
+++ b/InteractiveClassroom/View/MacOS/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 /// Settings used to configure how questions are presented and scored.
 struct SettingsView: View {
+    @StateObject private var connectionManager = PeerConnectionManager()
     @State private var timeLimit: Int = 60
     @State private var correctAnswer: String = ""
     @State private var anonymous: Bool = false
@@ -12,6 +13,12 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
+            Section("Connection") {
+                if let code = connectionManager.hostCode {
+                    Text("Key: \(code)")
+                }
+                Text(connectionManager.connectionStatus)
+            }
             Section("Question") {
                 Stepper(value: $timeLimit, in: 10...3600, step: 10) {
                     Text("Time Limit: \(timeLimit) s")
@@ -30,6 +37,9 @@ struct SettingsView: View {
         }
         .padding(20)
         .frame(minWidth: 400, minHeight: 300)
+        .onAppear {
+            connectionManager.startHosting()
+        }
     }
 }
 #endif

--- a/InteractiveClassroom/View/iOS/ServerConnectView.swift
+++ b/InteractiveClassroom/View/iOS/ServerConnectView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import MultipeerConnectivity
+
+#if os(iOS)
+struct ServerConnectView: View {
+    @StateObject private var connectionManager = PeerConnectionManager()
+    @State private var selectedPeer: MCPeerID?
+    @State private var passcode: String = ""
+
+    var body: some View {
+        VStack {
+            List(connectionManager.availablePeers, id: \.self) { peer in
+                Button(peer.displayName) {
+                    selectedPeer = peer
+                }
+            }
+            .overlay {
+                if connectionManager.availablePeers.isEmpty {
+                    Text("Searching for servers...")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Text(connectionManager.connectionStatus)
+                .padding()
+        }
+        .navigationTitle("Select Server")
+        .sheet(item: $selectedPeer) { peer in
+            VStack(spacing: 16) {
+                Text("Enter 6-digit key for \(peer.displayName)")
+                TextField("123456", text: $passcode)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .multilineTextAlignment(TextAlignment.center)
+                    .keyboardType(.numberPad)
+                Button("Connect") {
+                    connectionManager.connect(to: peer, passcode: passcode)
+                    passcode = ""
+                    selectedPeer = nil
+                }
+                Button("Cancel") {
+                    selectedPeer = nil
+                    passcode = ""
+                }
+            }
+            .padding()
+            .presentationDetents([.medium])
+        }
+        .onAppear {
+            connectionManager.startBrowsing()
+        }
+        .onDisappear {
+            connectionManager.stopBrowsing()
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ServerConnectView()
+    }
+}
+#endif
+

--- a/InteractiveClassroom/View/iOS/XXXView.swift
+++ b/InteractiveClassroom/View/iOS/XXXView.swift
@@ -1,7 +1,0 @@
-//
-//  XXXView.swift
-//  InteractiveClassroom
-//
-//  Created by zhb on 2025/8/12.
-//
-


### PR DESCRIPTION
## Summary
- Implement `PeerConnectionManager` using MultipeerConnectivity with 6-digit passcode
- Provide iOS `ServerConnectView` to select macOS server and enter passcode
- Show connection key and status in macOS settings; route iOS role selection to connection view
- Fix optional host name lookup and mark delegate callbacks `nonisolated` for Swift 6 compatibility
- Guard iOS connection view and replace unsupported text field modifiers to resolve build errors across platforms
- Restrict `ContentView` to iOS targets to eliminate linker errors on macOS builds

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b104d65448321a437ebf954d4749c