### PR TITLE
Fix Local Network permission request by matching Bonjour service type

### DIFF
--- a/InteractiveClassroom/Info.plist
+++ b/InteractiveClassroom/Info.plist
@@ -6,7 +6,7 @@
     <string>Allows the app to find nearby classroom servers</string>
     <key>NSBonjourServices</key>
     <array>
-        <string>_classroom._tcp</string>
+        <string>_iclassrm._tcp</string>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Correct Bonjour service type in Info.plist to `_iclassrm._tcp` to match MultipeerConnectivity service and trigger local network permission

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b3be525c083218ec6e049eb23c52e