### PR TITLE
Refactor peer identity handling

### DIFF
--- a/InteractiveClassroom/View/iOS/ServerConnectView.swift
+++ b/InteractiveClassroom/View/iOS/ServerConnectView.swift
@@ -4,13 +4,13 @@ import MultipeerConnectivity
 #if os(iOS)
 struct ServerConnectView: View {
     @StateObject private var connectionManager = PeerConnectionManager()
-    @State private var selectedPeer: MCPeerID?
+    @State private var selectedPeer: PeerConnectionManager.Peer?
     @State private var passcode: String = ""
 
     var body: some View {
         VStack {
-            List(connectionManager.availablePeers, id: \.self) { peer in
-                Button(peer.displayName) {
+            List(connectionManager.availablePeers) { peer in
+                Button(peer.peerID.displayName) {
                     selectedPeer = peer
                 }
             }
@@ -26,7 +26,7 @@ struct ServerConnectView: View {
         .navigationTitle("Select Server")
         .sheet(item: $selectedPeer) { peer in
             VStack(spacing: 16) {
-                Text("Enter 6-digit key for \(peer.displayName)")
+                Text("Enter 6-digit key for \(peer.peerID.displayName)")
                 TextField("123456", text: $passcode)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                     .multilineTextAlignment(TextAlignment.center)


### PR DESCRIPTION
## Summary
- wrap `MCPeerID` in custom `Peer` struct that safely conforms to `Identifiable`
- update peer connection logic and server connect view to use the wrapper

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b401b00008321aebe6ad6e2183fb8