### PR TITLE
Initialize PeerConnectionManager with ModelContext

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -13,13 +13,14 @@ struct InteractiveClassroomApp: App {
 #if os(macOS)
     @NSApplicationDelegateAdaptor(OverlayAppDelegate.self) var appDelegate
 #endif
-    @StateObject private var connectionManager = PeerConnectionManager()
+    @StateObject private var connectionManager: PeerConnectionManager
     private let container: ModelContainer
 
     init() {
         let schema = Schema([Item.self, ClientInfo.self])
-        container = try! ModelContainer(for: schema)
-        connectionManager.modelContext = ModelContext(container)
+        let container = try! ModelContainer(for: schema)
+        self.container = container
+        _connectionManager = StateObject(wrappedValue: PeerConnectionManager(modelContext: ModelContext(container)))
     }
 
     var body: some Scene {

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -32,7 +32,8 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         let role: String
     }
 
-    override init() {
+    init(modelContext: ModelContext? = nil) {
+        self.modelContext = modelContext
 #if os(macOS)
         myPeerID = MCPeerID(displayName: Host.current().localizedName ?? "macOS")
 #else
@@ -41,6 +42,10 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         session = MCSession(peer: myPeerID, securityIdentity: nil, encryptionPreference: .required)
         super.init()
         session.delegate = self
+    }
+
+    override convenience init() {
+        self.init(modelContext: nil)
     }
 
     func startHosting() {


### PR DESCRIPTION
## Summary
- Create `ModelContainer` before initializing `PeerConnectionManager`
- Pass `ModelContext` via `PeerConnectionManager` initializer and remove post-init configuration

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b4cb8ccc083218dfe37750bc1310a