### PR TITLE
feat: add course and lesson management

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -17,15 +17,17 @@ struct InteractiveClassroomApp: App {
     private let container: ModelContainer
 
     init() {
-        let schema = Schema([Item.self, ClientInfo.self])
+        let schema = Schema([Item.self, ClientInfo.self, Course.self, Lesson.self])
         let container = try! ModelContainer(for: schema)
         self.container = container
 
         let context = ModelContext(container)
         let manager = PeerConnectionManager(modelContext: context)
         _connectionManager = StateObject(wrappedValue: manager)
-        // Start hosting as soon as the application launches so the server is immediately available.
-        manager.startHosting()
+#if os(macOS)
+        // Show selection window; hosting will start after course and lesson are chosen.
+        CourseSelectionWindowController.shared.show(container: container, connectionManager: manager)
+#endif
     }
 
     var body: some Scene {

--- a/InteractiveClassroom/MacOS/CourseManagerWindowController.swift
+++ b/InteractiveClassroom/MacOS/CourseManagerWindowController.swift
@@ -1,0 +1,34 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import SwiftData
+
+/// Manages the window for course CRUD operations.
+final class CourseManagerWindowController: NSObject, NSWindowDelegate {
+    static let shared = CourseManagerWindowController()
+    private var window: NSWindow?
+
+    func show(container: ModelContainer) {
+        if window == nil {
+            let contentView = CourseManagerView()
+                .modelContainer(container)
+            let hosting = NSHostingView(rootView: contentView)
+            let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+                               styleMask: [.titled, .closable, .resizable],
+                               backing: .buffered,
+                               defer: false)
+            win.center()
+            win.contentView = hosting
+            win.isReleasedWhenClosed = false
+            win.delegate = self
+            window = win
+        }
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        window = nil
+    }
+}
+#endif

--- a/InteractiveClassroom/MacOS/CourseSelectionWindowController.swift
+++ b/InteractiveClassroom/MacOS/CourseSelectionWindowController.swift
@@ -1,0 +1,40 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import SwiftData
+
+/// Displays the initial course and lesson selection window.
+final class CourseSelectionWindowController: NSObject, NSWindowDelegate {
+    static let shared = CourseSelectionWindowController()
+    private var window: NSWindow?
+
+    func show(container: ModelContainer, connectionManager: PeerConnectionManager) {
+        if window == nil {
+            let contentView = CourseSelectionView()
+                .environmentObject(connectionManager)
+                .modelContainer(container)
+            let hosting = NSHostingView(rootView: contentView)
+            let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 250),
+                               styleMask: [.titled, .closable],
+                               backing: .buffered,
+                               defer: false)
+            win.center()
+            win.contentView = hosting
+            win.isReleasedWhenClosed = false
+            win.delegate = self
+            window = win
+        }
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func close() {
+        window?.close()
+        window = nil
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        window = nil
+    }
+}
+#endif

--- a/InteractiveClassroom/MacOS/LessonManagerWindowController.swift
+++ b/InteractiveClassroom/MacOS/LessonManagerWindowController.swift
@@ -1,0 +1,34 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import SwiftData
+
+/// Manages the window for lesson CRUD operations within a course.
+final class LessonManagerWindowController: NSObject, NSWindowDelegate {
+    static let shared = LessonManagerWindowController()
+    private var window: NSWindow?
+
+    func show(for course: Course, container: ModelContainer) {
+        if window == nil {
+            let contentView = LessonManagerView(course: course)
+                .modelContainer(container)
+            let hosting = NSHostingView(rootView: contentView)
+            let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+                               styleMask: [.titled, .closable, .resizable],
+                               backing: .buffered,
+                               defer: false)
+            win.center()
+            win.contentView = hosting
+            win.isReleasedWhenClosed = false
+            win.delegate = self
+            window = win
+        }
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        window = nil
+    }
+}
+#endif

--- a/InteractiveClassroom/Model/ClientInfo.swift
+++ b/InteractiveClassroom/Model/ClientInfo.swift
@@ -17,7 +17,7 @@ final class ClientInfo {
     /// Indicates whether the client is currently connected.
     var isConnected: Bool
     /// Course this client belongs to.
-    @Relationship(inverse: \Course.clients) var course: Course?
+    @Relationship var course: Course?
 
     init(deviceName: String,
          nickname: String,

--- a/InteractiveClassroom/Model/ClientInfo.swift
+++ b/InteractiveClassroom/Model/ClientInfo.swift
@@ -16,18 +16,22 @@ final class ClientInfo {
     var lastConnected: Date
     /// Indicates whether the client is currently connected.
     var isConnected: Bool
+    /// Course this client belongs to.
+    @Relationship(inverse: \Course.clients) var course: Course?
 
     init(deviceName: String,
          nickname: String,
          role: String,
          ipAddress: String? = nil,
          lastConnected: Date = .now,
-         isConnected: Bool = true) {
+         isConnected: Bool = true,
+         course: Course? = nil) {
         self.deviceName = deviceName
         self.nickname = nickname
         self.role = role
         self.ipAddress = ipAddress
         self.lastConnected = lastConnected
         self.isConnected = isConnected
+        self.course = course
     }
 }

--- a/InteractiveClassroom/Model/Course.swift
+++ b/InteractiveClassroom/Model/Course.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftData
+
+/// Represents a teaching course which groups multiple lessons and clients.
+@Model
+final class Course {
+    /// Name of the course.
+    var name: String
+    /// Lessons under this course.
+    @Relationship(deleteRule: .cascade, inverse: \Lesson.course) var lessons: [Lesson] = []
+    /// Clients that joined this course.
+    @Relationship(deleteRule: .cascade, inverse: \ClientInfo.course) var clients: [ClientInfo] = []
+
+    init(name: String) {
+        self.name = name
+    }
+}

--- a/InteractiveClassroom/Model/Course.swift
+++ b/InteractiveClassroom/Model/Course.swift
@@ -7,9 +7,9 @@ final class Course {
     /// Name of the course.
     var name: String
     /// Lessons under this course.
-    @Relationship(deleteRule: .cascade, inverse: \Lesson.course) var lessons: [Lesson] = []
+    @Relationship(deleteRule: .cascade) var lessons: [Lesson] = []
     /// Clients that joined this course.
-    @Relationship(deleteRule: .cascade, inverse: \ClientInfo.course) var clients: [ClientInfo] = []
+    @Relationship(deleteRule: .cascade) var clients: [ClientInfo] = []
 
     init(name: String) {
         self.name = name

--- a/InteractiveClassroom/Model/Lesson.swift
+++ b/InteractiveClassroom/Model/Lesson.swift
@@ -13,7 +13,7 @@ final class Lesson {
     /// Raw data for student information collected in this lesson.
     var studentData: Data?
     /// Associated course.
-    @Relationship(inverse: \Course.lessons) var course: Course?
+    @Relationship var course: Course?
 
     init(title: String, date: Date = .now, course: Course? = nil, answerData: Data? = nil, studentData: Data? = nil) {
         self.title = title

--- a/InteractiveClassroom/Model/Lesson.swift
+++ b/InteractiveClassroom/Model/Lesson.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SwiftData
+
+/// Represents a single teaching session within a course.
+@Model
+final class Lesson {
+    /// Title or topic of the lesson.
+    var title: String
+    /// Date when the lesson occurs.
+    var date: Date
+    /// Raw data for answer statistics collected in this lesson.
+    var answerData: Data?
+    /// Raw data for student information collected in this lesson.
+    var studentData: Data?
+    /// Associated course.
+    @Relationship(inverse: \Course.lessons) var course: Course?
+
+    init(title: String, date: Date = .now, course: Course? = nil, answerData: Data? = nil, studentData: Data? = nil) {
+        self.title = title
+        self.date = date
+        self.course = course
+        self.answerData = answerData
+        self.studentData = studentData
+    }
+}

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -80,6 +80,17 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         connectionStatus = "Awaiting connection..."
     }
 
+    func stopHosting() {
+        advertiser?.stopAdvertisingPeer()
+        advertiser = nil
+        session.disconnect()
+        connectionStatus = "Not Connected"
+        teacherCode = nil
+        studentCode = nil
+        rolesByPeer.removeAll()
+        classStarted = false
+    }
+
     func startBrowsing() {
         browser = MCNearbyServiceBrowser(peer: myPeerID, serviceType: serviceType)
         browser?.delegate = self

--- a/InteractiveClassroom/View/MacOS/ClientsListView.swift
+++ b/InteractiveClassroom/View/MacOS/ClientsListView.swift
@@ -7,7 +7,10 @@ struct ClientsListView: View {
     @EnvironmentObject private var connectionManager: PeerConnectionManager
     @Environment(\.modelContext) private var modelContext
     // Fetch clients ordered by most recent connection and animate updates for timely refreshes.
-    @Query(sort: \ClientInfo.lastConnected, order: .reverse, animation: .default) private var clients: [ClientInfo]
+    @Query(sort: \ClientInfo.lastConnected, order: .reverse, animation: .default) private var allClients: [ClientInfo]
+    private var clients: [ClientInfo] {
+        allClients.filter { $0.course?.persistentModelID == connectionManager.currentCourse?.persistentModelID }
+    }
 
     var body: some View {
         VStack(alignment: .leading) {

--- a/InteractiveClassroom/View/MacOS/ClientsListView.swift
+++ b/InteractiveClassroom/View/MacOS/ClientsListView.swift
@@ -17,7 +17,11 @@ struct ClientsListView: View {
             Text("Connected Clients")
                 .font(.title2)
 
-            if clients.isEmpty {
+            if connectionManager.currentCourse == nil {
+                Text("Please select a course")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                    .padding()
+            } else if clients.isEmpty {
                 Text("No clients connected")
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
                     .padding()

--- a/InteractiveClassroom/View/MacOS/CourseManagerView.swift
+++ b/InteractiveClassroom/View/MacOS/CourseManagerView.swift
@@ -1,0 +1,52 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+/// Lists all courses and allows CRUD operations.
+struct CourseManagerView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Course.name, animation: .default) private var courses: [Course]
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text("Courses")
+                    .font(.title2)
+                Spacer()
+                Button("Add") {
+                    let course = Course(name: "New Course")
+                    modelContext.insert(course)
+                    try? modelContext.save()
+                }
+            }
+            if courses.isEmpty {
+                Text("No courses")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                    .padding()
+            } else {
+                Table(courses) {
+                    TableColumn("Name") { course in
+                        Text(course.name)
+                    }
+                    TableColumn("Lessons") { course in
+                        Button("Manage") {
+                            LessonManagerWindowController.shared.show(for: course, container: modelContext.container)
+                        }
+                    }
+                    TableColumn("") { course in
+                        Button(role: .destructive) {
+                            modelContext.delete(course)
+                            try? modelContext.save()
+                        } label: {
+                            Text("Delete")
+                        }
+                    }
+                }
+                .frame(minHeight: 300)
+            }
+        }
+        .padding()
+        .frame(minWidth: 600, minHeight: 400)
+    }
+}
+#endif

--- a/InteractiveClassroom/View/MacOS/CourseSelectionView.swift
+++ b/InteractiveClassroom/View/MacOS/CourseSelectionView.swift
@@ -1,0 +1,51 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+/// Initial window prompting user to select a course and lesson before starting service.
+struct CourseSelectionView: View {
+    @EnvironmentObject private var connectionManager: PeerConnectionManager
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Course.name, animation: .default) private var courses: [Course]
+    @State private var selectedCourse: Course?
+    @State private var selectedLesson: Lesson?
+
+    var lessons: [Lesson] {
+        selectedCourse?.lessons.sorted { $0.date < $1.date } ?? []
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Select Course and Lesson")
+                .font(.title3)
+            Picker("Course", selection: $selectedCourse) {
+                Text("None").tag(Optional<Course>.none)
+                ForEach(courses) { course in
+                    Text(course.name).tag(Optional(course))
+                }
+            }
+            .pickerStyle(.menu)
+            Picker("Lesson", selection: $selectedLesson) {
+                Text("None").tag(Optional<Lesson>.none)
+                ForEach(lessons) { lesson in
+                    Text(lesson.title).tag(Optional(lesson))
+                }
+            }
+            .pickerStyle(.menu)
+            HStack {
+                Spacer()
+                Button("Start") {
+                    guard let course = selectedCourse, let lesson = selectedLesson else { return }
+                    connectionManager.currentCourse = course
+                    connectionManager.currentLesson = lesson
+                    connectionManager.startHosting()
+                    CourseSelectionWindowController.shared.close()
+                }
+                .disabled(selectedCourse == nil || selectedLesson == nil)
+            }
+        }
+        .padding()
+        .frame(minWidth: 350, minHeight: 200)
+    }
+}
+#endif

--- a/InteractiveClassroom/View/MacOS/LessonManagerView.swift
+++ b/InteractiveClassroom/View/MacOS/LessonManagerView.swift
@@ -1,0 +1,53 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+/// Lists lessons for a specific course and allows CRUD operations.
+struct LessonManagerView: View {
+    @Environment(\.modelContext) private var modelContext
+    @ObservedObject var course: Course
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text("Lessons for \(course.name)")
+                    .font(.title2)
+                Spacer()
+                Button("Add") {
+                    let lesson = Lesson(title: "New Lesson", course: course)
+                    course.lessons.append(lesson)
+                    try? modelContext.save()
+                }
+            }
+            if course.lessons.isEmpty {
+                Text("No lessons")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                    .padding()
+            } else {
+                Table(course.lessons) {
+                    TableColumn("Title") { lesson in
+                        Text(lesson.title)
+                    }
+                    TableColumn("Date") { lesson in
+                        Text(lesson.date, format: Date.FormatStyle(date: .numeric, time: .shortened))
+                    }
+                    TableColumn("") { lesson in
+                        Button(role: .destructive) {
+                            if let index = course.lessons.firstIndex(of: lesson) {
+                                course.lessons.remove(at: index)
+                                modelContext.delete(lesson)
+                                try? modelContext.save()
+                            }
+                        } label: {
+                            Text("Delete")
+                        }
+                    }
+                }
+                .frame(minHeight: 300)
+            }
+        }
+        .padding()
+        .frame(minWidth: 600, minHeight: 400)
+    }
+}
+#endif

--- a/InteractiveClassroom/View/MacOS/LessonManagerView.swift
+++ b/InteractiveClassroom/View/MacOS/LessonManagerView.swift
@@ -5,7 +5,7 @@ import SwiftData
 /// Lists lessons for a specific course and allows CRUD operations.
 struct LessonManagerView: View {
     @Environment(\.modelContext) private var modelContext
-    @ObservedObject var course: Course
+    @Bindable var course: Course
 
     var body: some View {
         VStack(alignment: .leading) {

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -6,21 +6,34 @@ import SwiftData
 /// Content displayed in the menu bar extra for macOS builds.
 struct MenuBarView: View {
     @EnvironmentObject private var connectionManager: PeerConnectionManager
-    @Environment(\.modelContext) private var modelContext
 
     var body: some View {
+        if connectionManager.currentLesson == nil {
+            Button("Start Class") {
+                if let container = connectionManager.modelContext?.container {
+                    CourseSelectionWindowController.shared.show(container: container,
+                                                               connectionManager: connectionManager)
+                }
+            }
+        } else {
+            Button("End Class") {
+                connectionManager.stopHosting()
+                connectionManager.currentCourse = nil
+                connectionManager.currentLesson = nil
+            }
+        }
         Button("Show Screen") {
             OverlayWindowController.shared.show()
         }
         Button("Clients") {
-            ClientsWindowController.shared.show(container: modelContext.container, connectionManager: connectionManager)
+            if let container = connectionManager.modelContext?.container {
+                ClientsWindowController.shared.show(container: container,
+                                                   connectionManager: connectionManager)
+            }
         }
         Button("Courses") {
-            CourseManagerWindowController.shared.show(container: modelContext.container)
-        }
-        Button("Lessons") {
-            if let course = connectionManager.currentCourse {
-                LessonManagerWindowController.shared.show(for: course, container: modelContext.container)
+            if let container = connectionManager.modelContext?.container {
+                CourseManagerWindowController.shared.show(container: container)
             }
         }
         if #available(macOS 13, *) {

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -15,6 +15,14 @@ struct MenuBarView: View {
         Button("Clients") {
             ClientsWindowController.shared.show(container: modelContext.container, connectionManager: connectionManager)
         }
+        Button("Courses") {
+            CourseManagerWindowController.shared.show(container: modelContext.container)
+        }
+        Button("Lessons") {
+            if let course = connectionManager.currentCourse {
+                LessonManagerWindowController.shared.show(for: course, container: modelContext.container)
+            }
+        }
         if #available(macOS 13, *) {
             SettingsLink {
                 Text("Settings")


### PR DESCRIPTION
## Summary
- add SwiftData `Course` and `Lesson` models with relationships to clients
- start service only after selecting a course and lesson
- provide macOS windows for managing courses and lessons

## Testing
- `swift build` *(fails: Could not find Package.swift)*

Please add the new Swift files to the Xcode project after merging.

------
https://chatgpt.com/codex/tasks/task_e_689c01b7d5708321902b5e177b0c8687