### PR TITLE
Add overlay font scaling and auto-hide overlay

### DIFF
--- a/InteractiveClassroom/Controller/MacOS/OverlayWindowController.swift
+++ b/InteractiveClassroom/Controller/MacOS/OverlayWindowController.swift
@@ -15,6 +15,11 @@ final class OverlayWindowController {
         window?.orderFront(nil)
     }
 
+    /// Hides the overlay window if it is currently visible.
+    func hide() {
+        window?.orderOut(nil)
+    }
+
     private func createWindow() {
         let frame = NSScreen.main?.frame ?? .zero
         let panel = TransparentOverlayWindow(contentRect: frame)

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -95,6 +95,9 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         studentCode = nil
         rolesByPeer.removeAll()
         classStarted = false
+        #if os(macOS)
+        OverlayWindowController.shared.hide()
+        #endif
     }
 
     func startBrowsing() {

--- a/InteractiveClassroom/View/MacOS/Overlay/OverlayNamesView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/OverlayNamesView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct OverlayNamesView: View {
     let names: [String]
     @ScaledMetric private var trailingPadding: CGFloat = 32
+    @ScaledMetric private var baseFontSize: CGFloat = 20
+    @AppStorage("overlayFontScale") private var overlayFontScale: Double = 1.0
 
     var body: some View {
         HStack {
@@ -12,7 +14,7 @@ struct OverlayNamesView: View {
             VStack(alignment: .trailing, spacing: 8) {
                 ForEach(names, id: \.self) { name in
                     Text(name)
-                        .font(.title3)
+                        .font(.system(size: baseFontSize * overlayFontScale))
                         .shadow(color: .black, radius: 1)
                 }
             }

--- a/InteractiveClassroom/View/MacOS/Overlay/OverlayStatsView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/OverlayStatsView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct OverlayStatsView: View {
     let stats: [String]
     @ScaledMetric private var leadingPadding: CGFloat = 32
+    @ScaledMetric private var baseFontSize: CGFloat = 20
+    @AppStorage("overlayFontScale") private var overlayFontScale: Double = 1.0
 
     var body: some View {
         HStack {
@@ -12,7 +14,7 @@ struct OverlayStatsView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     ForEach(stats, id: \.self) { stat in
                         Text(stat)
-                            .font(.title3)
+                            .font(.system(size: baseFontSize * overlayFontScale))
                             .shadow(color: .black, radius: 1)
                     }
                 }

--- a/InteractiveClassroom/View/MacOS/Overlay/OverlayTopBarView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/OverlayTopBarView.swift
@@ -7,18 +7,20 @@ struct OverlayTopBarView: View {
     let remainingTime: String
     @ScaledMetric private var horizontalPadding: CGFloat = 32
     @ScaledMetric private var verticalPadding: CGFloat = 32
+    @ScaledMetric private var baseFontSize: CGFloat = 34
+    @AppStorage("overlayFontScale") private var overlayFontScale: Double = 1.0
 
     var body: some View {
         VStack {
             HStack {
                 Text(questionType)
-                    .font(.largeTitle.weight(.bold))
+                    .font(.system(size: baseFontSize * overlayFontScale, weight: .bold))
                     .shadow(color: .black, radius: 2)
                     .padding(.leading, horizontalPadding)
                     .padding(.top, verticalPadding)
                 Spacer()
                 Text(remainingTime)
-                    .font(.largeTitle.weight(.bold))
+                    .font(.system(size: baseFontSize * overlayFontScale, weight: .bold))
                     .shadow(color: .black, radius: 2)
                     .padding(.trailing, horizontalPadding)
                     .padding(.top, verticalPadding)

--- a/InteractiveClassroom/View/MacOS/SettingsView.swift
+++ b/InteractiveClassroom/View/MacOS/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @State private var shuffleOptions: Bool = false
     @State private var allowModification: Bool = true
     @State private var score: Int = 1
+    @AppStorage("overlayFontScale") private var overlayFontScale: Double = 1.0
 
     var body: some View {
         Form {
@@ -35,6 +36,14 @@ struct SettingsView: View {
             }
             Section("Export") {
                 Button("Export Results") {}
+            }
+            Section("Overlay") {
+                HStack {
+                    Text("Font Scale")
+                    Slider(value: $overlayFontScale, in: 0.5...2.0, step: 0.1)
+                    Text("\(overlayFontScale, specifier: "%.1f")x")
+                        .frame(width: 40, alignment: .trailing)
+                }
             }
         }
         .padding(20)


### PR DESCRIPTION
## Summary
- allow adjusting overlay font size from settings
- scale overlay text based on user preference
- hide screen overlay automatically when ending a class

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c6ed43f7c832188b4bc1663963a2a