### PR TITLE
feat: show current course details on waiting screen

### DIFF
--- a/InteractiveClassroom/View/iOS/StudentWaitingView.swift
+++ b/InteractiveClassroom/View/iOS/StudentWaitingView.swift
@@ -1,19 +1,51 @@
 import SwiftUI
 
 #if os(iOS)
+/// Displays a waiting screen for students along with current course and lesson information.
 struct StudentWaitingView: View {
     @EnvironmentObject private var connectionManager: PeerConnectionManager
 
     var body: some View {
-        VStack {
-            if connectionManager.classStarted {
-                Text("Class has started.")
-            } else {
-                Text("Waiting for the teacher to start the class...")
-                    .multilineTextAlignment(.center)
-                    .padding()
+        List {
+            Section {
+                if connectionManager.classStarted {
+                    Text("Class has started.")
+                        .font(.title2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    Text("Waiting for the teacher to start the class...")
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+            }
+
+            if let course = connectionManager.currentCourse {
+                Section("Current Course") {
+                    Text(course.name)
+                        .font(.headline)
+                    Text(course.scheduledAt, format: .dateTime.year().month().day().hour().minute())
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    if !course.intro.isEmpty {
+                        Text(course.intro)
+                    }
+                }
+            }
+
+            if let lesson = connectionManager.currentLesson {
+                Section("Current Lesson") {
+                    Text(lesson.title)
+                        .font(.headline)
+                    Text(lesson.scheduledAt, format: .dateTime.year().month().day().hour().minute())
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    if !lesson.intro.isEmpty {
+                        Text(lesson.intro)
+                    }
+                }
             }
         }
+        .listStyle(.insetGrouped)
         .navigationTitle("Waiting")
     }
 }


### PR DESCRIPTION
## Summary
- display current course name, schedule, and description
- show current lesson title, time, and description

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project InteractiveClassroom.xcodeproj -scheme InteractiveClassroom -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c866863f083218e8bbc4fa4c57d6e