### PR TITLE
Fix pairing code error alert handling

### DIFF
--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -155,6 +155,10 @@ final class PeerConnectionManager: NSObject, ObservableObject {
     }
 
     func connect(to peer: Peer, passcode: String, nickname: String) {
+        // Update status immediately so UI can react even if the invitation is rejected
+        // before a session state change is reported. This ensures client-side alerts
+        // are triggered for invalid passcodes or other errors.
+        connectionStatus = "Connecting to \(peer.peerID.displayName)..."
         let payload = InvitationPayload(passcode: passcode, nickname: nickname)
         let context = try? JSONEncoder().encode(payload)
         browser?.invitePeer(peer.peerID, to: session, withContext: context, timeout: 30)


### PR DESCRIPTION
## Summary
- Update connection status immediately when attempting to connect so rejection triggers UI alert

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689d37110a54832192cfe2eff7928deb