### PR TITLE
Ensure macOS overlay fills screen and auto-opens

### DIFF
--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -214,6 +214,7 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         if let data = try? JSONEncoder().encode(message) {
             try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
         }
+        classStarted = true
         // macOS overlay window presentation is now handled by SwiftUI state.
     }
 

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -8,38 +8,45 @@ struct MenuBarView: View {
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
-        if connectionManager.currentLesson == nil {
-            Button("Start Class") {
-                openWindow(id: "courseSelection")
+        Group {
+            if connectionManager.currentLesson == nil {
+                Button("Start Class") {
+                    openWindow(id: "courseSelection")
+                }
+            } else {
+                Button("End Class") {
+                    connectionManager.stopHosting()
+                    connectionManager.currentCourse = nil
+                    connectionManager.currentLesson = nil
+                }
             }
-        } else {
-            Button("End Class") {
-                connectionManager.stopHosting()
-                connectionManager.currentCourse = nil
-                connectionManager.currentLesson = nil
+            Button("Show Screen") {
+                openWindow(id: "overlay")
+            }
+            Button("Clients") {
+                openWindow(id: "clients")
+            }
+            Button("Courses") {
+                openWindow(id: "courseManager")
+            }
+            if #available(macOS 13, *) {
+                SettingsLink {
+                    Text("Settings")
+                }
+            } else {
+                Button("Settings") {
+                    NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+                }
+            }
+            Divider()
+            Button("Quit") {
+                NSApp.terminate(nil)
             }
         }
-        Button("Show Screen") {
-            openWindow(id: "overlay")
-        }
-        Button("Clients") {
-            openWindow(id: "clients")
-        }
-        Button("Courses") {
-            openWindow(id: "courseManager")
-        }
-        if #available(macOS 13, *) {
-            SettingsLink {
-                Text("Settings")
+        .onChange(of: connectionManager.classStarted) { started in
+            if started {
+                openWindow(id: "overlay")
             }
-        } else {
-            Button("Settings") {
-                NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
-            }
-        }
-        Divider()
-        Button("Quit") {
-            NSApp.terminate(nil)
         }
     }
 }

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -1,5 +1,7 @@
+// swiftlint:disable file_length
 #if os(macOS)
 import SwiftUI
+import AppKit
 
 /// Overlay shown on the big screen during a quiz session.
 struct ScreenOverlayView: View {
@@ -18,8 +20,42 @@ struct ScreenOverlayView: View {
         .background(Color.clear)
         .ignoresSafeArea()
         .foregroundStyle(.white)
+        .background(WindowConfigurator())
     }
 }
+
+/// Helper view to configure the hosting window for a full-screen floating overlay.
+private struct WindowConfigurator: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let nsView = NSView()
+        DispatchQueue.main.async {
+            if let window = nsView.window {
+                configure(window)
+            }
+        }
+        return nsView
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            if let window = nsView.window {
+                configure(window)
+            }
+        }
+    }
+
+    private func configure(_ window: NSWindow) {
+        window.level = .screenSaver
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        if let screenFrame = NSScreen.main?.frame {
+            window.setFrame(screenFrame, display: true)
+        }
+        window.styleMask = [.borderless]
+        window.isOpaque = false
+        window.backgroundColor = .clear
+    }
+}
+
 #Preview {
     ScreenOverlayView()
 }


### PR DESCRIPTION
## Summary
- configure overlay window to be borderless, full-screen, and floating
- automatically open overlay when class starts via menu bar state
- set `classStarted` when broadcasting start command

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689ebee90260832184c6b7a70669e4f1