### PR TITLE
Refine macOS overlay lifecycle

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -59,9 +59,6 @@ struct InteractiveClassroomApp: App {
                 .environmentObject(connectionManager)
         }
         .modelContainer(container)
-        WindowGroup(id: "overlay") {
-            ScreenOverlayView()
-        }
         WindowGroup(id: "clients") {
             ClientsListView()
                 .environmentObject(connectionManager)

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -214,6 +214,7 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         if let data = try? JSONEncoder().encode(message) {
             try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
         }
+        classStarted = true
         // macOS overlay window presentation is now handled by SwiftUI state.
     }
 
@@ -397,6 +398,7 @@ extension PeerConnectionManager: MCSessionDelegate {
                     }
                 }
             case "endClass":
+                self.classStarted = false
                 self.serverDisconnected = true
                 self.userInitiatedDisconnect = true
                 self.session.disconnect()

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -6,40 +6,70 @@ import AppKit
 struct MenuBarView: View {
     @EnvironmentObject private var connectionManager: PeerConnectionManager
     @Environment(\.openWindow) private var openWindow
+    @State private var overlayWindow: NSWindow?
+
+    /// Presents the full-screen overlay window.
+    private func openOverlay() {
+        closeOverlay()
+        let controller = NSHostingController(rootView: ScreenOverlayView())
+        let window = NSWindow(contentViewController: controller)
+        window.isReleasedWhenClosed = false
+        window.makeKeyAndOrderFront(nil)
+        overlayWindow = window
+    }
+
+    /// Closes any existing overlay windows.
+    private func closeOverlay() {
+        overlayWindow?.close()
+        overlayWindow = nil
+        NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }.forEach { $0.close() }
+    }
 
     var body: some View {
-        if connectionManager.currentLesson == nil {
-            Button("Start Class") {
-                openWindow(id: "courseSelection")
+        Group {
+            if connectionManager.currentLesson == nil {
+                Button("Start Class") {
+                    openWindow(id: "courseSelection")
+                }
+            } else {
+                Button("End Class") {
+                    connectionManager.stopHosting()
+                    connectionManager.currentCourse = nil
+                    connectionManager.currentLesson = nil
+                    closeOverlay()
+                }
             }
-        } else {
-            Button("End Class") {
-                connectionManager.stopHosting()
-                connectionManager.currentCourse = nil
-                connectionManager.currentLesson = nil
+            if connectionManager.classStarted {
+                Button("Show Screen") {
+                    openOverlay()
+                }
+            }
+            Button("Clients") {
+                openWindow(id: "clients")
+            }
+            Button("Courses") {
+                openWindow(id: "courseManager")
+            }
+            if #available(macOS 13, *) {
+                SettingsLink {
+                    Text("Settings")
+                }
+            } else {
+                Button("Settings") {
+                    NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+                }
+            }
+            Divider()
+            Button("Quit") {
+                NSApp.terminate(nil)
             }
         }
-        Button("Show Screen") {
-            openWindow(id: "overlay")
-        }
-        Button("Clients") {
-            openWindow(id: "clients")
-        }
-        Button("Courses") {
-            openWindow(id: "courseManager")
-        }
-        if #available(macOS 13, *) {
-            SettingsLink {
-                Text("Settings")
+        .onChange(of: connectionManager.classStarted) { started in
+            if started {
+                openOverlay()
+            } else {
+                closeOverlay()
             }
-        } else {
-            Button("Settings") {
-                NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
-            }
-        }
-        Divider()
-        Button("Quit") {
-            NSApp.terminate(nil)
         }
     }
 }

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -1,5 +1,7 @@
+// swiftlint:disable file_length
 #if os(macOS)
 import SwiftUI
+import AppKit
 
 /// Overlay shown on the big screen during a quiz session.
 struct ScreenOverlayView: View {
@@ -18,8 +20,35 @@ struct ScreenOverlayView: View {
         .background(Color.clear)
         .ignoresSafeArea()
         .foregroundStyle(.white)
+        .background(WindowConfigurator())
     }
 }
+
+/// Helper view to configure the hosting window for a full-screen floating overlay.
+private struct WindowConfigurator: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        ConfigurableView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    private final class ConfigurableView: NSView {
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            guard let window = window else { return }
+            window.identifier = NSUserInterfaceItemIdentifier("overlay")
+            window.level = .screenSaver
+            window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+            if let screenFrame = NSScreen.main?.frame {
+                window.setFrame(screenFrame, display: true)
+            }
+            window.styleMask = [.borderless]
+            window.isOpaque = false
+            window.backgroundColor = .clear
+        }
+    }
+}
+
 #Preview {
     ScreenOverlayView()
 }


### PR DESCRIPTION
## Summary
- prevent overlay window from appearing at launch by removing its dedicated scene
- open and close overlay programmatically from the menu bar only after Start Class

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ebee90260832184c6b7a70669e4f1