### PR TITLE
Improve client connection and teacher roster handling

### DIFF
--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -208,6 +208,14 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         }
     }
 
+    /// Requests the current list of connected students from the server.
+    func requestStudentsList() {
+        let message = Message(type: "requestStudents", role: nil, students: nil, target: nil)
+        if let data = try? JSONEncoder().encode(message) {
+            try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
+        }
+    }
+
     /// Broadcasts a start-class command to the server.
     func startClass() {
         let message = Message(type: "startClass", role: nil, students: nil, target: nil)
@@ -389,6 +397,14 @@ extension PeerConnectionManager: MCSessionDelegate {
                 if self.advertiser != nil {
                     if let data = try? JSONEncoder().encode(message) {
                         try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
+                    }
+                }
+            case "requestStudents":
+                if self.advertiser != nil {
+                    let current = self.rolesByPeer.filter { $0.value == .student }.map { $0.key.displayName }
+                    let response = Message(type: "students", students: current)
+                    if let data = try? JSONEncoder().encode(response) {
+                        try? session.send(data, toPeers: [peerID], with: .reliable)
                     }
                 }
             case "disconnect":

--- a/InteractiveClassroom/View/iOS/ServerConnectView.swift
+++ b/InteractiveClassroom/View/iOS/ServerConnectView.swift
@@ -83,6 +83,13 @@ struct ServerConnectView: View {
             .padding()
             .presentationDetents([.medium])
         }
+        .onChange(of: selectedPeer) { _, peer in
+            if peer != nil {
+                viewModel.stopBrowsing()
+            } else {
+                viewModel.startBrowsing()
+            }
+        }
         .onAppear {
             viewModel.bind(to: connectionManager)
             viewModel.startBrowsing()
@@ -121,6 +128,16 @@ struct ServerConnectView: View {
             if server == nil {
                 navigateToTeacher = false
                 navigateToStudent = false
+            }
+        }
+        .onChange(of: connectionManager.serverDisconnected) { _, disconnected in
+            if disconnected {
+                navigateToTeacher = false
+                navigateToStudent = false
+                selectedPeer = nil
+                passcode = ""
+                nickname = ""
+                viewModel.startBrowsing()
             }
         }
     }

--- a/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
+++ b/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
@@ -16,6 +16,8 @@ final class TeacherDashboardViewModel: ObservableObject {
             .receive(on: RunLoop.main)
             .assign(to: \.students, on: self)
             .store(in: &cancellables)
+
+        manager.requestStudentsList()
     }
 
     func sendDisconnect(for student: String) {


### PR DESCRIPTION
## Summary
- Pause peer browsing during passcode entry to avoid UI stutter and ensure navigation resets on disconnect
- Allow teacher dashboard to request student roster and issue disconnect commands
- Handle server requests for student list in peer connection manager

## Testing
- `xcodebuild -list` *(failed: command not found)*
- `swift build` *(failed: Could not find Package.swift)*
- `swiftc -typecheck InteractiveClassroom/Model/PeerConnectionManager.swift` *(failed: no such module 'MultipeerConnectivity')*

------
https://chatgpt.com/codex/tasks/task_e_689efe9960448321b6728318b83531de