### PR TITLE
Improve connection handling and teacher tools

### DIFF
--- a/InteractiveClassroom/ContentView.swift
+++ b/InteractiveClassroom/ContentView.swift
@@ -12,11 +12,13 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject private var connectionManager: PeerConnectionManager
     @Environment(\.scenePhase) private var scenePhase
+    @State private var navigationID = UUID()
 
     var body: some View {
         NavigationStack {
             ServerConnectView()
         }
+        .id(navigationID)
         .alert("Disconnected", isPresented: $connectionManager.serverDisconnected) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -25,6 +27,16 @@ struct ContentView: View {
         .onChange(of: scenePhase) { _, phase in
             if phase == .background, connectionManager.myRole != nil {
                 connectionManager.disconnectFromServer()
+            }
+        }
+        .onChange(of: connectionManager.connectedServer) { _, server in
+            if server == nil {
+                navigationID = UUID()
+            }
+        }
+        .onChange(of: connectionManager.serverDisconnected) { _, disconnected in
+            if disconnected {
+                navigationID = UUID()
             }
         }
     }

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -208,6 +208,14 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         }
     }
 
+    /// Requests the current list of students from the server.
+    func requestStudentList() {
+        let message = Message(type: "requestStudents")
+        if let data = try? JSONEncoder().encode(message) {
+            try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
+        }
+    }
+
     /// Broadcasts a start-class command to the server.
     func startClass() {
         let message = Message(type: "startClass", role: nil, students: nil, target: nil)
@@ -395,6 +403,14 @@ extension PeerConnectionManager: MCSessionDelegate {
                 if let target = message.target {
                     if self.advertiser != nil {
                         self.disconnect(peerNamed: target)
+                    }
+                }
+            case "requestStudents":
+                if self.advertiser != nil {
+                    let currentStudents = self.rolesByPeer.filter { $0.value == .student }.map { $0.key.displayName }
+                    let response = Message(type: "students", students: currentStudents)
+                    if let data = try? JSONEncoder().encode(response) {
+                        try? session.send(data, toPeers: [peerID], with: .reliable)
                     }
                 }
             case "endClass":

--- a/InteractiveClassroom/View/iOS/ServerConnectView.swift
+++ b/InteractiveClassroom/View/iOS/ServerConnectView.swift
@@ -82,6 +82,12 @@ struct ServerConnectView: View {
             }
             .padding()
             .presentationDetents([.medium])
+            .onAppear { viewModel.stopBrowsing() }
+            .onDisappear {
+                passcode = ""
+                nickname = ""
+                viewModel.startBrowsing()
+            }
         }
         .onAppear {
             viewModel.bind(to: connectionManager)

--- a/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
+++ b/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
@@ -16,6 +16,8 @@ final class TeacherDashboardViewModel: ObservableObject {
             .receive(on: RunLoop.main)
             .assign(to: \.students, on: self)
             .store(in: &cancellables)
+
+        manager.requestStudentList()
     }
 
     func sendDisconnect(for student: String) {


### PR DESCRIPTION
## Summary
- Reset navigation stack when the server connection drops so clients return to server selection
- Pause peer browsing during passcode entry to reduce UI lag and resume afterwards
- Allow teachers to request the current student list and issue targeted disconnect commands

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689efe9960448321b6728318b83531de