### PR TITLE
Improve client connection handling and teacher controls

### DIFF
--- a/InteractiveClassroom/View/iOS/ServerConnectView.swift
+++ b/InteractiveClassroom/View/iOS/ServerConnectView.swift
@@ -88,6 +88,13 @@ struct ServerConnectView: View {
             viewModel.startBrowsing()
         }
         .onDisappear { viewModel.stopBrowsing() }
+        .onChange(of: selectedPeer) { _, newValue in
+            if newValue == nil {
+                viewModel.resumeBrowsing()
+            } else {
+                viewModel.pauseBrowsing()
+            }
+        }
         .alert("Connection Failed", isPresented: $viewModel.showError) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -119,6 +126,12 @@ struct ServerConnectView: View {
         }
         .onChange(of: connectionManager.connectedServer) { _, server in
             if server == nil {
+                navigateToTeacher = false
+                navigateToStudent = false
+            }
+        }
+        .onChange(of: connectionManager.serverDisconnected) { _, disconnected in
+            if disconnected {
                 navigateToTeacher = false
                 navigateToStudent = false
             }

--- a/InteractiveClassroom/ViewModel/ServerConnectViewModel.swift
+++ b/InteractiveClassroom/ViewModel/ServerConnectViewModel.swift
@@ -45,6 +45,14 @@ final class ServerConnectViewModel: ObservableObject {
         connectionManager?.stopBrowsing()
     }
 
+    func pauseBrowsing() {
+        connectionManager?.pauseBrowsing()
+    }
+
+    func resumeBrowsing() {
+        connectionManager?.resumeBrowsing()
+    }
+
     func connect(to peer: PeerConnectionManager.Peer, passcode: String, nickname: String) {
         awaitingConnection = true
         connectionManager?.connect(to: peer, passcode: passcode, nickname: nickname)

--- a/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
+++ b/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
@@ -16,6 +16,8 @@ final class TeacherDashboardViewModel: ObservableObject {
             .receive(on: RunLoop.main)
             .assign(to: \.students, on: self)
             .store(in: &cancellables)
+
+        manager.requestStudentsList()
     }
 
     func sendDisconnect(for student: String) {


### PR DESCRIPTION
## Summary
- Pause peer discovery without dropping the browser to avoid pairing input lag
- Reset navigation on disconnect to return to server selection
- Allow teacher client to request student list and disconnect specific students

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689efe9960448321b6728318b83531de