### PR TITLE
Improve disconnect handling and teacher student list management

### DIFF
--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -208,6 +208,15 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         }
     }
 
+    /// Requests the server to provide the current list of students.
+    func requestStudentList() {
+        guard advertiser == nil else { return }
+        let message = Message(type: "requestStudents", role: nil, students: nil, target: nil)
+        if let data = try? JSONEncoder().encode(message) {
+            try? session.send(data, toPeers: session.connectedPeers, with: .reliable)
+        }
+    }
+
     /// Broadcasts a start-class command to the server.
     func startClass() {
         let message = Message(type: "startClass", role: nil, students: nil, target: nil)
@@ -396,6 +405,10 @@ extension PeerConnectionManager: MCSessionDelegate {
                     if self.advertiser != nil {
                         self.disconnect(peerNamed: target)
                     }
+                }
+            case "requestStudents":
+                if self.advertiser != nil {
+                    self.updateStudents()
                 }
             case "endClass":
                 self.classStarted = false

--- a/InteractiveClassroom/View/iOS/ServerConnectView.swift
+++ b/InteractiveClassroom/View/iOS/ServerConnectView.swift
@@ -123,6 +123,12 @@ struct ServerConnectView: View {
                 navigateToStudent = false
             }
         }
+        .onChange(of: connectionManager.serverDisconnected) { _, disconnected in
+            if disconnected {
+                navigateToTeacher = false
+                navigateToStudent = false
+            }
+        }
     }
 
     /// Handles taps on a server row, respecting existing connections.

--- a/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
+++ b/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
@@ -16,6 +16,8 @@ final class TeacherDashboardViewModel: ObservableObject {
             .receive(on: RunLoop.main)
             .assign(to: \.students, on: self)
             .store(in: &cancellables)
+
+        manager.requestStudentList()
     }
 
     func sendDisconnect(for student: String) {


### PR DESCRIPTION
## Summary
- Ensure clients return to the Select Server screen when the connection drops
- Allow teachers to request the current student list from the server and disconnect individual students

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689f047bad7c8321824cfcc0f7742643