### PR TITLE
Simplify macOS settings and show connection status

### DIFF
--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -27,6 +27,13 @@ struct MenuBarView: View {
 
     var body: some View {
         Group {
+            if let t = connectionManager.teacherCode,
+               let s = connectionManager.studentCode {
+                Text("Teacher Key: \(t)")
+                Text("Student Key: \(s)")
+            }
+            Text(connectionManager.connectionStatus)
+            Divider()
             if connectionManager.currentLesson == nil {
                 Button("Start Class") {
                     openWindow(id: "courseSelection")

--- a/InteractiveClassroom/View/MacOS/SettingsView.swift
+++ b/InteractiveClassroom/View/MacOS/SettingsView.swift
@@ -2,42 +2,14 @@
 import SwiftUI
 import SwiftData
 
-/// Settings used to configure how questions are presented and scored.
+/// Settings for overlay appearance and behavior.
 struct SettingsView: View {
     @EnvironmentObject private var connectionManager: PeerConnectionManager
     @Environment(\.modelContext) private var modelContext
-    @State private var timeLimit: Int = 60
-    @State private var correctAnswer: String = ""
-    @State private var anonymous: Bool = false
-    @State private var shuffleOptions: Bool = false
-    @State private var allowModification: Bool = true
-    @State private var score: Int = 1
     @AppStorage("overlayFontScale") private var overlayFontScale: Double = 1.0
 
     var body: some View {
         Form {
-            Section("Connection") {
-                if let t = connectionManager.teacherCode, let s = connectionManager.studentCode {
-                    Text("Teacher Key: \(t)")
-                    Text("Student Key: \(s)")
-                }
-                Text(connectionManager.connectionStatus)
-            }
-            Section("Question") {
-                Stepper(value: $timeLimit, in: 10...3600, step: 10) {
-                    Text("Time Limit: \(timeLimit) s")
-                }
-                TextField("Correct Answer", text: $correctAnswer)
-                Toggle("Anonymous", isOn: $anonymous)
-                Toggle("Shuffle Options", isOn: $shuffleOptions)
-                Toggle("Allow Answer Changes", isOn: $allowModification)
-                Stepper(value: $score, in: 1...100) {
-                    Text("Score: \(score)")
-                }
-            }
-            Section("Export") {
-                Button("Export Results") {}
-            }
             Section("Overlay") {
                 HStack {
                     Text("Font Scale")


### PR DESCRIPTION
## Summary
- Streamline macOS settings to only include Font Scale
- Move connection status and pairing codes to the menu bar, separated from action buttons

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a04ceeb1748321be352cd2d624eae5