### PR TITLE
Refactor passcode entry to remove initial lag

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -37,8 +37,7 @@ struct InteractiveClassroomApp: App {
         }
         self.container = container
 
-        let context = ModelContext(container)
-        let manager = PeerConnectionManager(modelContext: context)
+        let manager = PeerConnectionManager(modelContext: container.mainContext)
         _connectionManager = StateObject(wrappedValue: manager)
     }
 

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -172,8 +172,7 @@ final class PeerConnectionManager: NSObject, ObservableObject {
     /// relationships are assigned using context-bound instances.
     private func resolvedCurrentCourse(in context: ModelContext) -> Course? {
         guard let course = currentCourse else { return nil }
-        let descriptor = FetchDescriptor<Course>(predicate: #Predicate { $0.persistentModelID == course.persistentModelID })
-        return try? context.fetch(descriptor).first
+        return context.model(for: course.persistentModelID) as? Course
     }
 
     /// Indicates whether the client is already connected to the specified peer.

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -168,6 +168,14 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         browser?.invitePeer(peer.peerID, to: session, withContext: context, timeout: 30)
     }
 
+    /// Resolves the current course within the specified model context to ensure
+    /// relationships are assigned using context-bound instances.
+    private func resolvedCurrentCourse(in context: ModelContext) -> Course? {
+        guard let course = currentCourse else { return nil }
+        let descriptor = FetchDescriptor<Course>(predicate: #Predicate { $0.persistentModelID == course.persistentModelID })
+        return try? context.fetch(descriptor).first
+    }
+
     /// Indicates whether the client is already connected to the specified peer.
     func isConnected(to peer: Peer) -> Bool {
         connectedServer == peer.peerID
@@ -315,12 +323,13 @@ extension PeerConnectionManager: MCNearbyServiceAdvertiserDelegate {
                 let descriptor = FetchDescriptor<ClientInfo>(predicate: predicate)
                 let results = (try? context.fetch(descriptor)) ?? []
                 let existing = results.first { $0.course?.persistentModelID == self.currentCourse?.persistentModelID }
+                let courseRef = self.resolvedCurrentCourse(in: context)
                 if let existing {
                     existing.nickname = payload?.nickname ?? existing.nickname
                     existing.role = self.rolesByPeer[peerID]?.rawValue ?? existing.role
                     existing.lastConnected = .now
                     existing.isConnected = true
-                    existing.course = self.currentCourse
+                    existing.course = courseRef
                 } else {
                     let info = ClientInfo(deviceName: name,
                                           nickname: payload?.nickname ?? "",
@@ -328,7 +337,7 @@ extension PeerConnectionManager: MCNearbyServiceAdvertiserDelegate {
                                           ipAddress: nil,
                                           lastConnected: .now,
                                           isConnected: true,
-                                          course: self.currentCourse)
+                                          course: courseRef)
                     context.insert(info)
                 }
                 try? context.save()

--- a/InteractiveClassroom/View/iOS/ServerConnectView.swift
+++ b/InteractiveClassroom/View/iOS/ServerConnectView.swift
@@ -56,8 +56,17 @@ struct ServerConnectView: View {
         }
         .navigationTitle("Select Server")
         .sheet(item: $selectedPeer) { peer in
-            PasscodeEntrySheet(peer: peer, viewModel: viewModel) {
+            PasscodeEntrySheet(peer: peer) { passcode, nickname in
+                viewModel.connect(to: peer, passcode: passcode, nickname: nickname)
+            } onDismiss: {
                 selectedPeer = nil
+            }
+        }
+        .onChange(of: selectedPeer) { _, peer in
+            if peer != nil {
+                viewModel.stopBrowsing()
+            } else {
+                viewModel.startBrowsing()
             }
         }
         .onAppear {
@@ -128,7 +137,7 @@ struct ServerConnectView: View {
 /// Sheet presented for entering a passcode and nickname when connecting to a server.
 private struct PasscodeEntrySheet: View {
     let peer: PeerConnectionManager.Peer
-    @ObservedObject var viewModel: ServerConnectViewModel
+    var connectAction: (String, String) -> Void
     var onDismiss: () -> Void
 
     @State private var passcode = ""
@@ -147,7 +156,7 @@ private struct PasscodeEntrySheet: View {
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .textInputAutocapitalization(.never)
             Button("Connect") {
-                viewModel.connect(to: peer, passcode: passcode, nickname: nickname)
+                connectAction(passcode, nickname)
                 passcode = ""
                 nickname = ""
                 onDismiss()

--- a/InteractiveClassroom/View/iOS/ServerConnectView.swift
+++ b/InteractiveClassroom/View/iOS/ServerConnectView.swift
@@ -6,8 +6,6 @@ struct ServerConnectView: View {
     @EnvironmentObject private var connectionManager: PeerConnectionManager
     @StateObject private var viewModel = ServerConnectViewModel()
     @State private var selectedPeer: PeerConnectionManager.Peer?
-    @State private var passcode: String = ""
-    @State private var nickname: String = ""
     @State private var navigateToTeacher = false
     @State private var navigateToStudent = false
     @State private var pendingPeer: PeerConnectionManager.Peer?
@@ -58,30 +56,9 @@ struct ServerConnectView: View {
         }
         .navigationTitle("Select Server")
         .sheet(item: $selectedPeer) { peer in
-            VStack(spacing: 16) {
-                Text("Enter 6-digit key for \(peer.peerID.displayName)")
-                TextField("123456", text: $passcode)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .multilineTextAlignment(.center)
-                    .keyboardType(.numberPad)
-                TextField("Nickname", text: $nickname)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .textInputAutocapitalization(.never)
-                Button("Connect") {
-                    viewModel.connect(to: peer, passcode: passcode, nickname: nickname)
-                    passcode = ""
-                    nickname = ""
-                    selectedPeer = nil
-                }
-                .disabled(passcode.isEmpty || nickname.isEmpty)
-                Button("Cancel") {
-                    selectedPeer = nil
-                    passcode = ""
-                    nickname = ""
-                }
+            PasscodeEntrySheet(peer: peer, viewModel: viewModel) {
+                selectedPeer = nil
             }
-            .padding()
-            .presentationDetents([.medium])
         }
         .onAppear {
             viewModel.bind(to: connectionManager)
@@ -146,6 +123,49 @@ struct ServerConnectView: View {
         }
     }
 
+}
+
+/// Sheet presented for entering a passcode and nickname when connecting to a server.
+private struct PasscodeEntrySheet: View {
+    let peer: PeerConnectionManager.Peer
+    @ObservedObject var viewModel: ServerConnectViewModel
+    var onDismiss: () -> Void
+
+    @State private var passcode = ""
+    @State private var nickname = ""
+    @FocusState private var passcodeFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Enter 6-digit key for \(peer.peerID.displayName)")
+            TextField("123456", text: $passcode)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .multilineTextAlignment(.center)
+                .keyboardType(.numberPad)
+                .focused($passcodeFocused)
+            TextField("Nickname", text: $nickname)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .textInputAutocapitalization(.never)
+            Button("Connect") {
+                viewModel.connect(to: peer, passcode: passcode, nickname: nickname)
+                passcode = ""
+                nickname = ""
+                onDismiss()
+            }
+            .disabled(passcode.isEmpty || nickname.isEmpty)
+            Button("Cancel", role: .cancel) {
+                onDismiss()
+            }
+        }
+        .padding()
+        .presentationDetents([.medium])
+        .onAppear {
+            // Focus the passcode field after sheet presentation to reduce input lag
+            DispatchQueue.main.async {
+                passcodeFocused = true
+            }
+        }
+    }
 }
 #Preview {
     NavigationStack {

--- a/InteractiveClassroom/View/iOS/ServerConnectView.swift
+++ b/InteractiveClassroom/View/iOS/ServerConnectView.swift
@@ -62,13 +62,6 @@ struct ServerConnectView: View {
                 selectedPeer = nil
             }
         }
-        .onChange(of: selectedPeer) { _, peer in
-            if peer != nil {
-                viewModel.stopBrowsing()
-            } else {
-                viewModel.startBrowsing()
-            }
-        }
         .onAppear {
             viewModel.bind(to: connectionManager)
             viewModel.startBrowsing()


### PR DESCRIPTION
## Summary
- Extract passcode input into dedicated `PasscodeEntrySheet` to avoid re-rendering the entire server list during text entry
- Auto-focus passcode field after sheet presentation for smoother first keystroke

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a04e6d3b0c8321b8e5cb2293386d29