### PR TITLE
Prevent duplicate macOS windows and refine student list

### DIFF
--- a/InteractiveClassroom/View/MacOS/ClientsListView.swift
+++ b/InteractiveClassroom/View/MacOS/ClientsListView.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 import SwiftUI
 import SwiftData
+import AppKit
 
 /// Displays a table of connected clients and allows disconnection.
 struct ClientsListView: View {
@@ -70,6 +71,7 @@ struct ClientsListView: View {
         }
         .onAppear {
             connectionManager.refreshConnectedClients()
+            NSApp.keyWindow?.identifier = NSUserInterfaceItemIdentifier("clients")
         }
         .onDisappear {
             refreshTimer.upstream.connect().cancel()

--- a/InteractiveClassroom/View/MacOS/CourseManagerView.swift
+++ b/InteractiveClassroom/View/MacOS/CourseManagerView.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 import SwiftUI
 import SwiftData
+import AppKit
 
 /// Lists all courses and allows CRUD operations.
 struct CourseManagerView: View {
@@ -49,6 +50,9 @@ struct CourseManagerView: View {
             .padding()
             .frame(minWidth: 600, minHeight: 400)
             .navigationTitle("Courses")
+            .onAppear {
+                NSApp.keyWindow?.identifier = NSUserInterfaceItemIdentifier("courseManager")
+            }
             .toolbar {
                 ToolbarItem {
                     Button {

--- a/InteractiveClassroom/View/MacOS/CourseSelectionView.swift
+++ b/InteractiveClassroom/View/MacOS/CourseSelectionView.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 import SwiftUI
 import SwiftData
+import AppKit
 
 /// Initial window prompting user to select a course and lesson before starting service.
 struct CourseSelectionView: View {
@@ -47,6 +48,9 @@ struct CourseSelectionView: View {
             .padding()
             .frame(minWidth: 350, minHeight: 200)
             .navigationTitle("Select Course and Lesson")
+            .onAppear {
+                NSApp.keyWindow?.identifier = NSUserInterfaceItemIdentifier("courseSelection")
+            }
         }
     }
 }

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -25,6 +25,16 @@ struct MenuBarView: View {
         NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }.forEach { $0.close() }
     }
 
+    /// Opens a window identified by `id` if one isn't already visible.
+    /// If the window exists, it is brought to the front instead of creating a duplicate.
+    private func openWindowIfNeeded(id: String) {
+        if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == id }) {
+            window.makeKeyAndOrderFront(nil)
+        } else {
+            openWindow(id: id)
+        }
+    }
+
     var body: some View {
         Group {
             if let t = connectionManager.teacherCode,
@@ -36,7 +46,7 @@ struct MenuBarView: View {
             Divider()
             if connectionManager.currentLesson == nil {
                 Button("Start Class") {
-                    openWindow(id: "courseSelection")
+                    openWindowIfNeeded(id: "courseSelection")
                 }
             } else {
                 Button("End Class") {
@@ -52,10 +62,10 @@ struct MenuBarView: View {
                 }
             }
             Button("Clients") {
-                openWindow(id: "clients")
+                openWindowIfNeeded(id: "clients")
             }
             Button("Courses") {
-                openWindow(id: "courseManager")
+                openWindowIfNeeded(id: "courseManager")
             }
             if #available(macOS 13, *) {
                 SettingsLink {

--- a/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
+++ b/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
@@ -51,17 +51,25 @@ struct TeacherDashboardView: View {
     }
 
     private var studentsView: some View {
-        List(viewModel.students, id: \.self) { student in
-            HStack {
-                Text(student)
-                Spacer()
-                Button {
-                    viewModel.sendDisconnect(for: student)
-                } label: {
-                    Image(systemName: "personalhotspot.slash")
+        List {
+            ForEach(viewModel.students, id: \.self) { student in
+                HStack {
+                    Text(student)
+                    Spacer()
+                    Button {
+                        viewModel.sendDisconnect(for: student)
+                    } label: {
+                        Image(systemName: "personalhotspot.slash")
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Disconnect Student")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Disconnect Student")
+            }
+        }
+        .overlay {
+            if viewModel.students.isEmpty {
+                Text("No students connected")
+                    .foregroundStyle(.secondary)
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid opening multiple copies of macOS "Start Class", "Clients", and "Courses" windows
- show a message when no students are connected on iOS while keeping list background consistent

## Testing
- `swift build` (fails: Could not find Package.swift)
- `xcodebuild -version` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a0551747b48321a8fac6b4cba9be52