### PR TITLE
Add class summarization overlay and teacher controls

### DIFF
--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -11,7 +11,7 @@ struct MenuBarView: View {
     /// Presents the full-screen overlay window.
     private func openOverlay() {
         closeOverlay()
-        let controller = NSHostingController(rootView: ScreenOverlayView())
+        let controller = NSHostingController(rootView: ScreenOverlayView().environmentObject(connectionManager))
         let window = NSWindow(contentViewController: controller)
         window.isReleasedWhenClosed = false
         window.makeKeyAndOrderFront(nil)
@@ -57,6 +57,10 @@ struct MenuBarView: View {
                 }
             }
             if connectionManager.classStarted {
+                Button(action: { connectionManager.summarizeClass() }) {
+                    Label("Class Summarize", systemImage: "doc.text")
+                }
+                .foregroundColor(.yellow)
                 Button("Show Screen") {
                     openOverlay()
                 }

--- a/InteractiveClassroom/View/MacOS/Overlay/ClassSummaryOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ClassSummaryOverlayView.swift
@@ -1,0 +1,39 @@
+#if os(macOS)
+import SwiftUI
+
+/// Overlay displaying the list of currently online students during class summary.
+struct ClassSummaryOverlayView: View {
+    let students: [String]
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [Color.blue.opacity(0.6), Color.purple.opacity(0.6)],
+                           startPoint: .topLeading, endPoint: .bottomTrailing)
+                .ignoresSafeArea()
+                .overlay(.ultraThinMaterial)
+            VStack(spacing: 24) {
+                Text("Class Summary")
+                    .font(.largeTitle)
+                    .bold()
+                if students.isEmpty {
+                    Text("No students connected")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                        .transition(.opacity)
+                } else {
+                    VStack(spacing: 16) {
+                        ForEach(students, id: \.self) { name in
+                            Text(name)
+                                .font(.title2)
+                                .transition(.move(edge: .bottom).combined(with: .opacity))
+                        }
+                    }
+                    .animation(.easeInOut, value: students)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .foregroundColor(.white)
+        }
+    }
+}
+#endif

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -5,15 +5,21 @@ import AppKit
 
 /// Overlay shown on the big screen during a quiz session.
 struct ScreenOverlayView: View {
+    @EnvironmentObject private var connectionManager: PeerConnectionManager
     @StateObject private var model = ScreenOverlayModel()
 
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                OverlayTopBarView(questionType: model.questionType.displayName,
-                                  remainingTime: model.remainingTimeString)
-                OverlayStatsView(stats: model.statsDisplay)
-                OverlayNamesView(names: model.submittedNames)
+                if connectionManager.showClassSummary {
+                    ClassSummaryOverlayView(students: connectionManager.students)
+                        .transition(.opacity)
+                } else {
+                    OverlayTopBarView(questionType: model.questionType.displayName,
+                                      remainingTime: model.remainingTimeString)
+                    OverlayStatsView(stats: model.statsDisplay)
+                    OverlayNamesView(names: model.submittedNames)
+                }
             }
             .frame(width: geometry.size.width, height: geometry.size.height)
         }
@@ -21,6 +27,7 @@ struct ScreenOverlayView: View {
         .ignoresSafeArea()
         .foregroundStyle(.white)
         .background(WindowConfigurator())
+        .animation(.easeInOut, value: connectionManager.showClassSummary)
     }
 }
 

--- a/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
+++ b/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
@@ -30,15 +30,26 @@ struct TeacherDashboardView: View {
         .navigationTitle("Teacher")
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                Button {
-                    viewModel.startClass()
-                } label: {
-                    Image(systemName: "play.fill")
-                    Text("Start Class").bold()
+                if connectionManager.classStarted {
+                    Button {
+                        viewModel.summarizeClass()
+                    } label: {
+                        Image(systemName: "doc.text")
+                        Text("Class Summarize").bold()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.yellow)
+                } else {
+                    Button {
+                        viewModel.startClass()
+                    } label: {
+                        Image(systemName: "play.fill")
+                        Text("Start Class").bold()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.green)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.green)
-                
+
                 Button {
                     connectionManager.disconnectFromServer()
                 } label: {

--- a/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
+++ b/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
@@ -27,5 +27,9 @@ final class TeacherDashboardViewModel: ObservableObject {
     func startClass() {
         connectionManager?.startClass()
     }
+
+    func summarizeClass() {
+        connectionManager?.summarizeClass()
+    }
 }
 


### PR DESCRIPTION
## Summary
- Switch teacher Start Class button to yellow Class Summarize button and send summary request
- Handle class summary requests and show animated student list overlay with gradient background
- Wire macOS menu bar and overlay to support summary mode

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a05bb860d48321bc1139e44949284b