### PR TITLE
Refactor overlay into interaction-based system

### DIFF
--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -11,7 +11,7 @@ struct MenuBarView: View {
     /// Presents the full-screen overlay window.
     private func openOverlay() {
         closeOverlay()
-        let controller = NSHostingController(rootView: ScreenOverlayView())
+        let controller = NSHostingController(rootView: ScreenOverlayView().environmentObject(connectionManager))
         let window = NSWindow(contentViewController: controller)
         window.isReleasedWhenClosed = false
         window.makeKeyAndOrderFront(nil)
@@ -57,6 +57,18 @@ struct MenuBarView: View {
                 }
             }
             if connectionManager.classStarted {
+                if connectionManager.activeInteraction == .classSummary {
+                    Button(action: { connectionManager.toggleInteractionVisibility() }) {
+                        Label(connectionManager.interactionVisible ? "Hide Summary" : "Show Summary",
+                              systemImage: connectionManager.interactionVisible ? "eye.slash" : "eye")
+                    }
+                    .foregroundColor(.yellow)
+                } else {
+                    Button(action: { connectionManager.startInteraction(.classSummary) }) {
+                        Label("Class Summarize", systemImage: "doc.text")
+                    }
+                    .foregroundColor(.yellow)
+                }
                 Button("Show Screen") {
                     openOverlay()
                 }
@@ -81,8 +93,8 @@ struct MenuBarView: View {
                 NSApp.terminate(nil)
             }
         }
-        .onChange(of: connectionManager.classStarted) { started in
-            if started {
+        .onChange(of: connectionManager.activeInteraction) { interaction in
+            if interaction != nil {
                 openOverlay()
             } else {
                 closeOverlay()

--- a/InteractiveClassroom/View/MacOS/Overlay/ClassSummaryOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ClassSummaryOverlayView.swift
@@ -1,0 +1,42 @@
+#if os(macOS)
+import SwiftUI
+
+/// Overlay displaying the list of currently online students during class summary.
+struct ClassSummaryOverlayView: View {
+    @EnvironmentObject private var connectionManager: PeerConnectionManager
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [Color.blue.opacity(0.6), Color.purple.opacity(0.6)],
+                           startPoint: .topLeading, endPoint: .bottomTrailing)
+                .background(.ultraThinMaterial)
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Text("Class Summary")
+                    .font(.largeTitle)
+                    .bold()
+                let list = connectionManager.students
+                if list.isEmpty {
+                    Text("No students connected")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                        .transition(.opacity)
+                } else {
+                    VStack(spacing: 16) {
+                        ForEach(list, id: \.self) { name in
+                            Text(name)
+                                .font(.title2)
+                                .transition(.move(edge: .bottom).combined(with: .opacity))
+                        }
+                    }
+                    .animation(.easeInOut, value: list)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .foregroundColor(.white)
+            .transition(.scale.combined(with: .opacity))
+        }
+    }
+}
+#endif

--- a/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
+++ b/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
@@ -30,15 +30,48 @@ struct TeacherDashboardView: View {
         .navigationTitle("Teacher")
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                Button {
-                    viewModel.startClass()
-                } label: {
-                    Image(systemName: "play.fill")
-                    Text("Start Class").bold()
+                if connectionManager.classStarted {
+                    if connectionManager.activeInteraction == .classSummary {
+                        HStack(spacing: 8) {
+                            Button {
+                                viewModel.toggleInteractionVisibility()
+                            } label: {
+                                Image(systemName: connectionManager.interactionVisible ? "eye.slash" : "eye")
+                                Text(connectionManager.interactionVisible ? "Hide Summary" : "Show Summary").bold()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.yellow)
+
+                            Button {
+                                viewModel.endClass()
+                            } label: {
+                                Image(systemName: "stop.fill")
+                                Text("End Class").bold()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.red)
+                        }
+                    } else {
+                        Button {
+                            viewModel.startClassSummary()
+                        } label: {
+                            Image(systemName: "doc.text")
+                            Text("Class Summarize").bold()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.yellow)
+                    }
+                } else {
+                    Button {
+                        viewModel.startClass()
+                    } label: {
+                        Image(systemName: "play.fill")
+                        Text("Start Class").bold()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.green)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.green)
-                
+
                 Button {
                     connectionManager.disconnectFromServer()
                 } label: {

--- a/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
+++ b/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
@@ -27,5 +27,17 @@ final class TeacherDashboardViewModel: ObservableObject {
     func startClass() {
         connectionManager?.startClass()
     }
+
+    func startClassSummary() {
+        connectionManager?.startInteraction(.classSummary)
+    }
+
+    func toggleInteractionVisibility() {
+        connectionManager?.toggleInteractionVisibility()
+    }
+
+    func endClass() {
+        connectionManager?.endClass()
+    }
 }
 


### PR DESCRIPTION
## Summary
- Track a single active overlay interaction with shared visibility state
- Show interaction content and a persistent eye toggle in the macOS overlay while hiding the menu bar
- Provide teacher and menu bar controls to start class summaries and hide or show the interaction layer

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -version` *(fails: command not found: xcodebuild)*
- `swiftlint` *(fails: command not found: swiftlint)*

------
https://chatgpt.com/codex/tasks/task_e_68a05bb860d48321bc1139e44949284b