### PR TITLE
Animate server summary overlay and fix teacher toggle

### DIFF
--- a/InteractiveClassroom/Model/Interaction.swift
+++ b/InteractiveClassroom/Model/Interaction.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Represents a type of interactive activity shown on the overlay.
+enum Interaction: String, Codable {
+    /// Displays a list of online students at the end of class.
+    case classSummary
+    // Future interactions such as quizzes can be added here.
+}

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -30,6 +30,10 @@ final class PeerConnectionManager: NSObject, ObservableObject {
     @Published var myRole: UserRole?
     @Published var students: [String] = []
     @Published var classStarted: Bool = false
+    /// Currently active overlay interaction, if any.
+    @Published var activeInteraction: Interaction?
+    /// Determines whether the active interaction's content is visible.
+    @Published var interactionVisible: Bool = true
     /// Indicates that the client lost connection to the server.
     @Published var serverDisconnected: Bool = false
     /// Currently connected server when acting as a client.
@@ -63,19 +67,25 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         let target: String?
         let course: CoursePayload?
         let lesson: LessonPayload?
+        let interaction: String?
+        let visible: Bool?
 
         init(type: String,
              role: String? = nil,
              students: [String]? = nil,
              target: String? = nil,
              course: CoursePayload? = nil,
-             lesson: LessonPayload? = nil) {
+             lesson: LessonPayload? = nil,
+             interaction: String? = nil,
+             visible: Bool? = nil) {
             self.type = type
             self.role = role
             self.students = students
             self.target = target
             self.course = course
             self.lesson = lesson
+            self.interaction = interaction
+            self.visible = visible
         }
     }
 
@@ -120,6 +130,9 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         connectionStatus = "Awaiting connection..."
         sessions.removeAll()
         refreshConnectedClients()
+        classStarted = false
+        activeInteraction = nil
+        interactionVisible = true
     }
 
     func stopHosting() {
@@ -144,6 +157,8 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         studentCode = nil
         rolesByPeer.removeAll()
         classStarted = false
+        activeInteraction = nil
+        interactionVisible = true
     }
 
     func startBrowsing() {
@@ -210,6 +225,8 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         myRole = nil
         students.removeAll()
         classStarted = false
+        activeInteraction = nil
+        interactionVisible = true
         currentCourse = nil
         currentLesson = nil
         connectedServer = nil
@@ -244,18 +261,71 @@ final class PeerConnectionManager: NSObject, ObservableObject {
 
     /// Broadcasts a start-class command to the server.
     func startClass() {
-        let message = Message(type: "startClass", role: nil, students: nil, target: nil)
+        let message = Message(type: "startClass")
         if let data = try? JSONEncoder().encode(message) {
             if advertiser != nil {
                 for sess in sessions.values where !sess.connectedPeers.isEmpty {
                     try? sess.send(data, toPeers: sess.connectedPeers, with: .reliable)
                 }
                 classStarted = true
+                activeInteraction = nil
+                interactionVisible = true
             } else if let server = connectedServer {
                 try? session.send(data, toPeers: [server], with: .reliable)
             }
         }
         // macOS overlay window presentation is now handled by SwiftUI state.
+    }
+
+    /// Starts a new overlay interaction, replacing any existing one.
+    func startInteraction(_ interaction: Interaction) {
+        let message = Message(type: "interaction", interaction: interaction.rawValue)
+        if let data = try? JSONEncoder().encode(message) {
+            if advertiser != nil {
+                for sess in sessions.values where !sess.connectedPeers.isEmpty {
+                    try? sess.send(data, toPeers: sess.connectedPeers, with: .reliable)
+                }
+                activeInteraction = interaction
+                interactionVisible = true
+            } else if let server = connectedServer {
+                try? session.send(data, toPeers: [server], with: .reliable)
+                activeInteraction = interaction
+                interactionVisible = true
+            }
+        }
+    }
+
+    /// Toggles the visibility of the current interaction.
+    func toggleInteractionVisibility() {
+        setInteractionVisible(!interactionVisible)
+    }
+
+    /// Sets the visibility of the current interaction and notifies peers.
+    func setInteractionVisible(_ visible: Bool) {
+        let message = Message(type: "interactionVisibility", visible: visible)
+        if let data = try? JSONEncoder().encode(message) {
+            if advertiser != nil {
+                interactionVisible = visible
+                for sess in sessions.values where !sess.connectedPeers.isEmpty {
+                    try? sess.send(data, toPeers: sess.connectedPeers, with: .reliable)
+                }
+            } else if let server = connectedServer {
+                try? session.send(data, toPeers: [server], with: .reliable)
+                interactionVisible = visible
+            }
+        }
+    }
+
+    /// Ends the current class session.
+    func endClass() {
+        let message = Message(type: "endClass")
+        if let data = try? JSONEncoder().encode(message) {
+            if advertiser != nil {
+                stopHosting()
+            } else if let server = connectedServer {
+                try? session.send(data, toPeers: [server], with: .reliable)
+            }
+        }
     }
 
     /// Updates the internal student list and notifies the teacher if connected.
@@ -441,6 +511,30 @@ extension PeerConnectionManager: MCSessionDelegate {
                 self.students = message.students ?? []
             case "startClass":
                 self.classStarted = true
+                self.activeInteraction = nil
+                self.interactionVisible = true
+                if self.advertiser != nil {
+                    if let data = try? JSONEncoder().encode(message) {
+                        for sess in self.sessions.values where !sess.connectedPeers.isEmpty {
+                            try? sess.send(data, toPeers: sess.connectedPeers, with: .reliable)
+                        }
+                    }
+                }
+            case "interaction":
+                if let name = message.interaction, let inter = Interaction(rawValue: name) {
+                    self.activeInteraction = inter
+                    self.interactionVisible = true
+                    if self.advertiser != nil {
+                        if let data = try? JSONEncoder().encode(message) {
+                            for sess in self.sessions.values where !sess.connectedPeers.isEmpty {
+                                try? sess.send(data, toPeers: sess.connectedPeers, with: .reliable)
+                            }
+                        }
+                    }
+                }
+            case "interactionVisibility":
+                let visible = message.visible ?? true
+                self.interactionVisible = visible
                 if self.advertiser != nil {
                     if let data = try? JSONEncoder().encode(message) {
                         for sess in self.sessions.values where !sess.connectedPeers.isEmpty {
@@ -459,11 +553,17 @@ extension PeerConnectionManager: MCSessionDelegate {
                     self.updateStudents()
                 }
             case "endClass":
-                self.classStarted = false
-                self.serverDisconnected = true
-                self.userInitiatedDisconnect = true
-                session.disconnect()
-                self.myRole = nil
+                if self.advertiser != nil {
+                    self.stopHosting()
+                } else {
+                    self.classStarted = false
+                    self.activeInteraction = nil
+                    self.interactionVisible = true
+                    self.serverDisconnected = true
+                    self.userInitiatedDisconnect = true
+                    session.disconnect()
+                    self.myRole = nil
+                }
             case "state":
                 if let course = message.course {
                     self.currentCourse = Course(name: course.name, intro: course.intro, scheduledAt: course.scheduledAt)

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -11,7 +11,7 @@ struct MenuBarView: View {
     /// Presents the full-screen overlay window.
     private func openOverlay() {
         closeOverlay()
-        let controller = NSHostingController(rootView: ScreenOverlayView())
+        let controller = NSHostingController(rootView: ScreenOverlayView().environmentObject(connectionManager))
         let window = NSWindow(contentViewController: controller)
         window.isReleasedWhenClosed = false
         window.makeKeyAndOrderFront(nil)
@@ -57,6 +57,18 @@ struct MenuBarView: View {
                 }
             }
             if connectionManager.classStarted {
+                if let interaction = connectionManager.activeInteraction, interaction == .classSummary {
+                    Button(action: { connectionManager.toggleInteractionVisibility() }) {
+                        Label(connectionManager.interactionVisible ? "Hide Summary" : "Show Summary",
+                              systemImage: connectionManager.interactionVisible ? "eye.slash" : "eye")
+                    }
+                    .foregroundColor(.yellow)
+                } else {
+                    Button(action: { connectionManager.startInteraction(.classSummary) }) {
+                        Label("Class Summarize", systemImage: "doc.text")
+                    }
+                    .foregroundColor(.yellow)
+                }
                 Button("Show Screen") {
                     openOverlay()
                 }

--- a/InteractiveClassroom/View/MacOS/Overlay/ClassSummaryOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ClassSummaryOverlayView.swift
@@ -1,0 +1,43 @@
+#if os(macOS)
+import SwiftUI
+
+/// Overlay displaying the list of currently online students during class summary.
+struct ClassSummaryOverlayView: View {
+    @EnvironmentObject private var connectionManager: PeerConnectionManager
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [Color.blue.opacity(0.6), Color.purple.opacity(0.6)],
+                           startPoint: .topLeading, endPoint: .bottomTrailing)
+                .background(.ultraThinMaterial)
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Text("Class Summary")
+                    .font(.largeTitle)
+                    .bold()
+                let list = connectionManager.students
+                if list.isEmpty {
+                    Text("No students connected")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                        .transition(.opacity)
+                } else {
+                    VStack(spacing: 16) {
+                        ForEach(list, id: \.self) { name in
+                            Text(name)
+                                .font(.title2)
+                                .transition(.move(edge: .bottom).combined(with: .opacity))
+                        }
+                    }
+                    .animation(.easeInOut, value: list)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .foregroundColor(.white)
+            .transition(.scale.combined(with: .opacity))
+        }
+        .animation(.easeInOut, value: connectionManager.students)
+    }
+}
+#endif

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -5,15 +5,38 @@ import AppKit
 
 /// Overlay shown on the big screen during a quiz session.
 struct ScreenOverlayView: View {
-    @StateObject private var model = ScreenOverlayModel()
+    @EnvironmentObject private var connectionManager: PeerConnectionManager
 
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                OverlayTopBarView(questionType: model.questionType.displayName,
-                                  remainingTime: model.remainingTimeString)
-                OverlayStatsView(stats: model.statsDisplay)
-                OverlayNamesView(names: model.submittedNames)
+                if let interaction = connectionManager.activeInteraction, connectionManager.interactionVisible {
+                    switch interaction {
+                    case .classSummary:
+                        ClassSummaryOverlayView()
+                            .transition(.opacity)
+                    }
+                }
+
+                if connectionManager.activeInteraction != nil {
+                    VStack {
+                        Spacer()
+                        HStack {
+                            Spacer()
+                            Button {
+                                withAnimation { connectionManager.toggleInteractionVisibility() }
+                            } label: {
+                                Image(systemName: connectionManager.interactionVisible ? "eye.slash" : "eye")
+                                    .padding(12)
+                                    .background(Color.black.opacity(0.4))
+                                    .clipShape(Circle())
+                            }
+                            .buttonStyle(.plain)
+                            .padding()
+                            .accessibilityLabel(connectionManager.interactionVisible ? "Hide Interaction" : "Show Interaction")
+                        }
+                    }
+                }
             }
             .frame(width: geometry.size.width, height: geometry.size.height)
         }
@@ -21,6 +44,18 @@ struct ScreenOverlayView: View {
         .ignoresSafeArea()
         .foregroundStyle(.white)
         .background(WindowConfigurator())
+        .animation(.easeInOut, value: connectionManager.interactionVisible)
+        .onAppear { updateMenuBar() }
+        .onChange(of: connectionManager.interactionVisible) { _ in updateMenuBar() }
+        .onChange(of: connectionManager.activeInteraction) { _ in updateMenuBar() }
+    }
+
+    private func updateMenuBar() {
+        if connectionManager.activeInteraction != nil && connectionManager.interactionVisible {
+            NSApp.presentationOptions.insert(.hideMenuBar)
+        } else {
+            NSApp.presentationOptions.remove(.hideMenuBar)
+        }
     }
 }
 

--- a/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
+++ b/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
@@ -30,15 +30,48 @@ struct TeacherDashboardView: View {
         .navigationTitle("Teacher")
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                Button {
-                    viewModel.startClass()
-                } label: {
-                    Image(systemName: "play.fill")
-                    Text("Start Class").bold()
+                if connectionManager.classStarted {
+                    if let interaction = connectionManager.activeInteraction, interaction == .classSummary {
+                        HStack(spacing: 8) {
+                            Button {
+                                viewModel.toggleInteractionVisibility()
+                            } label: {
+                                Image(systemName: connectionManager.interactionVisible ? "eye.slash" : "eye")
+                                Text(connectionManager.interactionVisible ? "Hide Summary" : "Show Summary").bold()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.yellow)
+
+                            Button {
+                                viewModel.endClass()
+                            } label: {
+                                Image(systemName: "stop.fill")
+                                Text("End Class").bold()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.red)
+                        }
+                    } else {
+                        Button {
+                            viewModel.startClassSummary()
+                        } label: {
+                            Image(systemName: "doc.text")
+                            Text("Class Summarize").bold()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.yellow)
+                    }
+                } else {
+                    Button {
+                        viewModel.startClass()
+                    } label: {
+                        Image(systemName: "play.fill")
+                        Text("Start Class").bold()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.green)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.green)
-                
+
                 Button {
                     connectionManager.disconnectFromServer()
                 } label: {

--- a/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
+++ b/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
@@ -27,5 +27,17 @@ final class TeacherDashboardViewModel: ObservableObject {
     func startClass() {
         connectionManager?.startClass()
     }
+
+    func startClassSummary() {
+        connectionManager?.startInteraction(.classSummary)
+    }
+
+    func toggleInteractionVisibility() {
+        connectionManager?.toggleInteractionVisibility()
+    }
+
+    func endClass() {
+        connectionManager?.endClass()
+    }
 }
 


### PR DESCRIPTION
## Summary
- Introduce generic interaction state with visibility control to manage overlay activities
- Display class summary as an interaction with synchronized hide/show toggles
- Update teacher and menu bar controls to start interactions and toggle visibility

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -version` *(fails: command not found: xcodebuild)*
- `swiftlint` *(fails: command not found: swiftlint)*


------
https://chatgpt.com/codex/tasks/task_e_68a05bb860d48321bc1139e44949284b