### PR TITLE
Refactor overlay to support dynamic interactive content

### DIFF
--- a/InteractiveClassroom/Model/Interaction.swift
+++ b/InteractiveClassroom/Model/Interaction.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftUI
+
+/// Lifecycle specification for an interaction.
+enum InteractionLifecycle: Codable, Equatable {
+    case infinite
+    case finite(seconds: Int)
+
+    private enum CodingKeys: String, CodingKey { case type, seconds }
+    private enum Kind: String, Codable { case infinite, finite }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .type)
+        switch kind {
+        case .infinite:
+            self = .infinite
+        case .finite:
+            let secs = try container.decode(Int.self, forKey: .seconds)
+            self = .finite(seconds: secs)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .infinite:
+            try container.encode(Kind.infinite, forKey: .type)
+        case .finite(let seconds):
+            try container.encode(Kind.finite, forKey: .type)
+            try container.encode(seconds, forKey: .seconds)
+        }
+    }
+}
+
+/// Request payload used to initiate an interaction from the teacher client.
+struct InteractionRequest: Codable {
+    /// Simplified template placeholder for future expansion.
+    enum Template: String, Codable {
+        case fullScreen
+        case floatingCorner
+    }
+
+    var template: Template
+    var lifecycle: InteractionLifecycle
+    /// Placeholder text representing the interactive content.
+    var text: String
+
+    /// Builds an overlay container based on the request.
+    func makeOverlay() -> OverlayContent {
+        let overlayTemplate: OverlayTemplate
+        switch template {
+        case .fullScreen:
+            overlayTemplate = .fullScreen(color: .black)
+        case .floatingCorner:
+            overlayTemplate = .floatingCorner(position: .bottomRight)
+        }
+        return OverlayContent(template: overlayTemplate) {
+            Text(text)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        }
+    }
+}
+
+/// Represents a running interaction with its start time.
+struct Interaction {
+    let request: InteractionRequest
+    let startedAt: Date = Date()
+}

--- a/InteractiveClassroom/Model/OverlayContent.swift
+++ b/InteractiveClassroom/Model/OverlayContent.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Corner positions for floating overlay content.
+enum OverlayCorner {
+    case topLeft, topRight, bottomLeft, bottomRight
+}
+
+/// Supported templates for overlay content.
+enum OverlayTemplate {
+    /// Full-screen content with a blurred color background.
+    case fullScreen(color: Color)
+    /// Floating content anchored to one corner without any background.
+    case floatingCorner(position: OverlayCorner)
+}
+
+/// A type-erased container for overlay content views.
+struct OverlayContent {
+    let template: OverlayTemplate
+    let view: AnyView
+
+    init<Content: View>(template: OverlayTemplate, @ViewBuilder content: () -> Content) {
+        self.template = template
+        self.view = AnyView(content())
+    }
+}

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -11,7 +11,8 @@ struct MenuBarView: View {
     /// Presents the full-screen overlay window.
     private func openOverlay() {
         closeOverlay()
-        let controller = NSHostingController(rootView: ScreenOverlayView())
+        let controller = NSHostingController(rootView: ScreenOverlayView()
+            .environmentObject(connectionManager))
         let window = NSWindow(contentViewController: controller)
         window.isReleasedWhenClosed = false
         window.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
## Summary
- Implement type-erased overlay content model with full-screen and corner templates
- Expose overlay presentation APIs in PeerConnectionManager
- Replace overlay rendering with a dynamic container and visibility toggle button
- Pass connection manager to overlay window from menu bar
- Add interaction lifecycle model and server APIs for starting/stopping timed activities
- Clear overlay content whenever interactions finish or are terminated
- Broadcast interaction start/stop messages and treat class start as an interaction
- Ensure end-class commands terminate and hide any active interaction
- Route interaction messaging through the server bridge and forward commands to clients without peer-to-peer traffic

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

## Additional Notes
- Add `Model/OverlayContent.swift` and `Model/Interaction.swift` to the Xcode project to compile the new overlay system.


------
https://chatgpt.com/codex/tasks/task_e_68a18e6e9ac08321817812f5e6ea8083