### PR TITLE
Rename server StartClass to OpenClassroom

### DIFF
--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -45,6 +45,8 @@ final class PeerConnectionManager: NSObject, ObservableObject {
 
     /// Content currently presented on the screen overlay.
     @Published var overlayContent: OverlayContent?
+    /// Indicates whether the overlay currently hosts any content.
+    var overlayHasContent: Bool { overlayContent != nil }
     /// Controls visibility of the overlay's content while keeping the overlay itself visible.
     @Published var isOverlayContentVisible: Bool = false
     /// Currently running interaction, if any.
@@ -145,7 +147,8 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         self.init(modelContext: nil)
     }
 
-    func startHosting() {
+    /// Opens the classroom service and begins advertising for connections.
+    func openClassroom() {
         teacherCode = String(format: "%06d", Int.random(in: 0..<1_000_000))
         studentCode = String(format: "%06d", Int.random(in: 0..<1_000_000))
         advertiser = MCNearbyServiceAdvertiser(peer: myPeerID, discoveryInfo: nil, serviceType: serviceType)
@@ -154,9 +157,12 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         connectionStatus = "Awaiting connection..."
         sessions.removeAll()
         refreshConnectedClients()
+        overlayContent = nil
+        isOverlayContentVisible = false
     }
 
-    func stopHosting() {
+    /// Ends the classroom session and disconnects all clients.
+    func endClass() {
         endInteraction()
         advertiser?.stopAdvertisingPeer()
         advertiser = nil

--- a/InteractiveClassroom/View/MacOS/CourseSelectionView.swift
+++ b/InteractiveClassroom/View/MacOS/CourseSelectionView.swift
@@ -35,11 +35,11 @@ struct CourseSelectionView: View {
                 .pickerStyle(.menu)
                 HStack {
                     Spacer()
-                    Button("Start") {
+                    Button("Open Classroom") {
                         guard let course = selectedCourse, let lesson = selectedLesson else { return }
                         connectionManager.currentCourse = course
                         connectionManager.currentLesson = lesson
-                        connectionManager.startHosting()
+                        connectionManager.openClassroom()
                         dismiss()
                     }
                     .disabled(selectedCourse == nil || selectedLesson == nil)

--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -45,21 +45,16 @@ struct MenuBarView: View {
             }
             Text(connectionManager.connectionStatus)
             Divider()
-            if connectionManager.currentLesson == nil {
-                Button("Start Class") {
+            if connectionManager.teacherCode == nil {
+                Button("Open Classroom") {
                     openWindowIfNeeded(id: "courseSelection")
                 }
             } else {
                 Button("End Class") {
-                    connectionManager.stopHosting()
+                    connectionManager.endClass()
                     connectionManager.currentCourse = nil
                     connectionManager.currentLesson = nil
                     closeOverlay()
-                }
-            }
-            if connectionManager.classStarted {
-                Button("Show Screen") {
-                    openOverlay()
                 }
             }
             Button("Clients") {
@@ -82,8 +77,8 @@ struct MenuBarView: View {
                 NSApp.terminate(nil)
             }
         }
-        .onChange(of: connectionManager.classStarted) { started in
-            if started {
+        .onChange(of: connectionManager.teacherCode) { code in
+            if code != nil {
                 openOverlay()
             } else {
                 closeOverlay()

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -2,6 +2,7 @@
 import SwiftUI
 #if os(macOS)
 import AppKit
+import CoreGraphics
 #endif
 
 /// Full-screen overlay container responsible for presenting interactive content.
@@ -58,7 +59,7 @@ private struct WindowConfigurator: NSViewRepresentable {
             super.viewDidMoveToWindow()
             guard let window = window else { return }
             window.identifier = NSUserInterfaceItemIdentifier("overlay")
-            window.level = .screenSaver
+            window.level = NSWindow.Level(CGShieldingWindowLevel())
             window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
             if let screenFrame = NSScreen.main?.frame {
                 window.setFrame(screenFrame, display: true)
@@ -66,6 +67,7 @@ private struct WindowConfigurator: NSViewRepresentable {
             window.styleMask = [.borderless]
             window.isOpaque = false
             window.backgroundColor = .clear
+            window.orderFrontRegardless()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Rename server-side start/stop methods to `openClassroom` and `endClass`
- Launch overlay window when opening the classroom and provide overlay content state
- Update macOS UI buttons to "Open Classroom"/"End Class" and bind overlay state to lesson selection
- Ensure overlay activates on classroom start and shields the macOS menu bar

## Testing
- ❌ `swift build` *(Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a19c9cf0688321a876662ddd3b2ab4