### PR TITLE
Keep menu bar icon usable when overlay is active

### DIFF
--- a/InteractiveClassroom/View/MacOS/MenuBarView.swift
+++ b/InteractiveClassroom/View/MacOS/MenuBarView.swift
@@ -11,7 +11,8 @@ struct MenuBarView: View {
     /// Presents the full-screen overlay window.
     private func openOverlay() {
         closeOverlay()
-        NSApp.presentationOptions = [.hideDock, .hideMenuBar]
+        // Auto-hide system chrome but keep the menu bar accessible when needed.
+        NSApp.presentationOptions = [.autoHideDock, .autoHideMenuBar]
         let controller = NSHostingController(rootView: ScreenOverlayView()
             .environmentObject(connectionManager))
         let window = NSWindow(contentViewController: controller)

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -62,7 +62,9 @@ private struct WindowConfigurator: NSViewRepresentable {
             super.viewDidMoveToWindow()
             guard let window = window else { return }
             window.identifier = NSUserInterfaceItemIdentifier("overlay")
-            window.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+            // Place the overlay below the system menu bar so status items remain
+            // interactive while still covering the rest of the screen.
+            window.level = .mainMenu
             window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
             if let screenFrame = NSScreen.main?.frame {
                 window.setFrame(screenFrame, display: true)


### PR DESCRIPTION
## Summary
- Place full-screen overlay below macOS menu bar so status items stay clickable
- Auto-hide dock and menu bar instead of disabling them to retain access during class

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project InteractiveClassroom.xcodeproj -scheme InteractiveClassroom -sdk macosx -configuration Debug build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b24289508321bd41911f334ad2d4