### PR TITLE
feat: add class countdown interaction

### DIFF
--- a/InteractiveClassroom/Model/CountdownService.swift
+++ b/InteractiveClassroom/Model/CountdownService.swift
@@ -12,12 +12,12 @@ final class CountdownService: ObservableObject {
 
     func start(onCompletion: @escaping @MainActor () -> Void) {
         task?.cancel()
-        task = Task { [weak self] in
+        task = Task { @MainActor [weak self] in
             while let self, self.remainingSeconds > 0 {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 self.remainingSeconds -= 1
             }
-            await onCompletion()
+            onCompletion()
         }
     }
 

--- a/InteractiveClassroom/Model/CountdownService.swift
+++ b/InteractiveClassroom/Model/CountdownService.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Combine
+
+@MainActor
+final class CountdownService: ObservableObject {
+    @Published private(set) var remainingSeconds: Int
+    private var task: Task<Void, Never>?
+
+    init(seconds: Int) {
+        self.remainingSeconds = max(0, seconds)
+    }
+
+    func start(onCompletion: @escaping @MainActor () -> Void) {
+        task?.cancel()
+        task = Task { [weak self] in
+            while let self, self.remainingSeconds > 0 {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                self.remainingSeconds -= 1
+            }
+            await onCompletion()
+        }
+    }
+
+    func stop() {
+        task?.cancel()
+        task = nil
+    }
+}

--- a/InteractiveClassroom/Model/Interaction.swift
+++ b/InteractiveClassroom/Model/Interaction.swift
@@ -84,7 +84,9 @@ struct InteractionRequest: Codable {
     var content: Content
 
     /// Builds an overlay container based on the request.
-    func makeOverlay() -> OverlayContent {
+    /// - Parameter countdownService: Optional service used for countdown interactions
+    ///   to maintain timer state even when the overlay view is removed.
+    func makeOverlay(countdownService: CountdownService? = nil) -> OverlayContent {
         let overlayTemplate: OverlayTemplate
         switch template {
         case .fullScreen:
@@ -100,7 +102,11 @@ struct InteractionRequest: Codable {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding()
             case .countdown:
-                CountdownOverlayView(seconds: lifecycle.secondsValue ?? 0)
+                if let service = countdownService {
+                    CountdownOverlayView(service: service)
+                } else {
+                    CountdownOverlayView(service: CountdownService(seconds: lifecycle.secondsValue ?? 0))
+                }
             }
         }
     }

--- a/InteractiveClassroom/Model/Interaction.swift
+++ b/InteractiveClassroom/Model/Interaction.swift
@@ -86,6 +86,7 @@ struct InteractionRequest: Codable {
     /// Builds an overlay container based on the request.
     /// - Parameter countdownService: Optional service used for countdown interactions
     ///   to maintain timer state even when the overlay view is removed.
+    @MainActor
     func makeOverlay(countdownService: CountdownService? = nil) -> OverlayContent {
         let overlayTemplate: OverlayTemplate
         switch template {

--- a/InteractiveClassroom/Model/Interaction.swift
+++ b/InteractiveClassroom/Model/Interaction.swift
@@ -31,6 +31,11 @@ enum InteractionLifecycle: Codable, Equatable {
             try container.encode(seconds, forKey: .seconds)
         }
     }
+
+    /// Returns the associated seconds if the lifecycle is finite.
+    var secondsValue: Int? {
+        if case let .finite(seconds) = self { return seconds } else { return nil }
+    }
 }
 
 /// Request payload used to initiate an interaction from the teacher client.
@@ -43,8 +48,40 @@ struct InteractionRequest: Codable {
 
     var template: Template
     var lifecycle: InteractionLifecycle
-    /// Placeholder text representing the interactive content.
-    var text: String
+
+    /// Content type for the interaction.
+    enum Content: Codable, Equatable {
+        case text(String)
+        case countdown
+
+        private enum CodingKeys: String, CodingKey { case type, text }
+        private enum Kind: String, Codable { case text, countdown }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let kind = try container.decode(Kind.self, forKey: .type)
+            switch kind {
+            case .text:
+                let value = try container.decode(String.self, forKey: .text)
+                self = .text(value)
+            case .countdown:
+                self = .countdown
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .text(let value):
+                try container.encode(Kind.text, forKey: .type)
+                try container.encode(value, forKey: .text)
+            case .countdown:
+                try container.encode(Kind.countdown, forKey: .type)
+            }
+        }
+    }
+
+    var content: Content
 
     /// Builds an overlay container based on the request.
     func makeOverlay() -> OverlayContent {
@@ -56,10 +93,15 @@ struct InteractionRequest: Codable {
             overlayTemplate = .floatingCorner(position: .bottomRight)
         }
         return OverlayContent(template: overlayTemplate) {
-            Text(text)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .padding()
+            switch content {
+            case .text(let text):
+                Text(text)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding()
+            case .countdown:
+                CountdownOverlayView(seconds: lifecycle.secondsValue ?? 0)
+            }
         }
     }
 }

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -217,7 +217,7 @@ final class PeerConnectionManager: NSObject, ObservableObject {
             countdownService = service
             presentOverlay(content: request.makeOverlay(countdownService: service))
             service.start { [weak self] in
-                await self?.endInteraction()
+                self?.endInteraction()
             }
         } else {
             presentOverlay(content: request.makeOverlay())

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -314,8 +314,13 @@ final class PeerConnectionManager: NSObject, ObservableObject {
     }
 
     /// Broadcasts a start-class command to the server.
-    func startClass() {
-        let request = InteractionRequest(template: .fullScreen, lifecycle: .infinite, text: "")
+    func startClass(at startDate: Date) {
+        let seconds = max(0, Int(startDate.timeIntervalSinceNow))
+        let request = InteractionRequest(
+            template: .fullScreen,
+            lifecycle: .finite(seconds: seconds),
+            content: .countdown
+        )
         startInteraction(request, broadcast: false)
         let message = Message(type: "startClass", interaction: request)
         sendMessageToServer(message)

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -222,9 +222,9 @@ final class PeerConnectionManager: NSObject, ObservableObject {
         } else {
             presentOverlay(content: request.makeOverlay())
             if case let .finite(seconds) = request.lifecycle {
-                interactionTask = Task { [weak self] in
+                interactionTask = Task { @MainActor [weak self] in
                     try? await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
-                    await self?.endInteraction()
+                    self?.endInteraction()
                 }
             }
         }

--- a/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
@@ -1,21 +1,15 @@
 #if os(macOS) || os(iOS)
 import SwiftUI
-import Combine
 
 /// A countdown view showing minutes and seconds with animations.
 struct CountdownOverlayView: View {
-    @State private var remaining: Int
+    @ObservedObject var service: CountdownService
     @State private var isVisible = false
     @State private var tick = false
-    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-
-    init(seconds: Int) {
-        _remaining = State(initialValue: max(seconds, 0))
-    }
 
     private var formattedTime: String {
-        let minutes = remaining / 60
-        let seconds = remaining % 60
+        let minutes = service.remainingSeconds / 60
+        let seconds = service.remainingSeconds % 60
         return String(format: "%02d:%02d", minutes, seconds)
     }
 
@@ -40,9 +34,7 @@ struct CountdownOverlayView: View {
                 isVisible = true
             }
         }
-        .onReceive(timer) { _ in
-            guard remaining > 0 else { return }
-            remaining -= 1
+        .onChange(of: service.remainingSeconds) { _ in
             tick.toggle()
         }
     }

--- a/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
@@ -2,25 +2,49 @@
 import SwiftUI
 import Combine
 
-/// A simple countdown view displaying remaining seconds in the center.
+/// A countdown view showing minutes and seconds with animations.
 struct CountdownOverlayView: View {
     @State private var remaining: Int
+    @State private var isVisible = false
+    @State private var tick = false
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     init(seconds: Int) {
         _remaining = State(initialValue: max(seconds, 0))
     }
 
+    private var formattedTime: String {
+        let minutes = remaining / 60
+        let seconds = remaining % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
     var body: some View {
-        Text("\(remaining)")
-            .font(.system(size: 120, weight: .bold, design: .rounded))
-            .foregroundColor(.white)
-            .monospacedDigit()
-            .onReceive(timer) { _ in
-                if remaining > 0 { remaining -= 1 }
+        VStack(spacing: 24) {
+            Text("Class Starts In")
+                .font(.title)
+                .foregroundColor(.white)
+            Text(formattedTime)
+                .font(.system(size: 120, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+                .monospacedDigit()
+                .scaleEffect(tick ? 1.1 : 1.0)
+                .animation(.easeInOut(duration: 0.25), value: tick)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .multilineTextAlignment(.center)
+        .opacity(isVisible ? 1 : 0)
+        .scaleEffect(isVisible ? 1 : 0.9)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                isVisible = true
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .multilineTextAlignment(.center)
+        }
+        .onReceive(timer) { _ in
+            guard remaining > 0 else { return }
+            remaining -= 1
+            tick.toggle()
+        }
     }
 }
 #endif

--- a/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
@@ -17,6 +17,7 @@ struct CountdownOverlayView: View {
         VStack(spacing: 24) {
             Text("Class Starts In")
                 .font(.title)
+                .bold()
                 .foregroundColor(.white)
             Text(formattedTime)
                 .font(.system(size: 120, weight: .bold, design: .rounded))

--- a/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
@@ -1,0 +1,26 @@
+#if os(macOS) || os(iOS)
+import SwiftUI
+import Combine
+
+/// A simple countdown view displaying remaining seconds in the center.
+struct CountdownOverlayView: View {
+    @State private var remaining: Int
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    init(seconds: Int) {
+        _remaining = State(initialValue: max(seconds, 0))
+    }
+
+    var body: some View {
+        Text("\(remaining)")
+            .font(.system(size: 120, weight: .bold, design: .rounded))
+            .foregroundColor(.white)
+            .monospacedDigit()
+            .onReceive(timer) { _ in
+                if remaining > 0 { remaining -= 1 }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .multilineTextAlignment(.center)
+    }
+}
+#endif

--- a/InteractiveClassroom/View/iOS/StartClassPopoverView.swift
+++ b/InteractiveClassroom/View/iOS/StartClassPopoverView.swift
@@ -1,0 +1,30 @@
+#if os(iOS)
+import SwiftUI
+
+/// Popover allowing teachers to schedule a class start time.
+struct StartClassPopoverView: View {
+    var onSchedule: (Date) -> Void
+    @State private var selectedDate: Date = Date()
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 16) {
+            DatePicker("Start Time", selection: $selectedDate, displayedComponents: [.hourAndMinute])
+                .datePickerStyle(.wheel)
+            HStack {
+                Button("Start Now") {
+                    onSchedule(Date())
+                    dismiss()
+                }
+                Spacer()
+                Button("Schedule") {
+                    onSchedule(selectedDate)
+                    dismiss()
+                }
+            }
+        }
+        .padding()
+        .presentationCompactAdaptation(.none)
+    }
+}
+#endif

--- a/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
+++ b/InteractiveClassroom/View/iOS/TeacherDashboardView.swift
@@ -5,6 +5,7 @@ struct TeacherDashboardView: View {
     @EnvironmentObject private var connectionManager: PeerConnectionManager
     @StateObject private var viewModel = TeacherDashboardViewModel()
     @State private var selectedTab = 0
+    @State private var showStartPopover = false
 
     private let tabs = [
         TabItem(icon: "person.3.fill", title: "Students"),
@@ -31,13 +32,18 @@ struct TeacherDashboardView: View {
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 Button {
-                    viewModel.startClass()
+                    showStartPopover = true
                 } label: {
                     Image(systemName: "play.fill")
                     Text("Start Class").bold()
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.green)
+                .popover(isPresented: $showStartPopover, attachmentAnchor: .point(.bottom), arrowEdge: .bottom) {
+                    StartClassPopoverView { date in
+                        viewModel.startClass(at: date)
+                    }
+                }
                 
                 Button {
                     connectionManager.disconnectFromServer()

--- a/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
+++ b/InteractiveClassroom/ViewModel/TeacherDashboardViewModel.swift
@@ -24,8 +24,8 @@ final class TeacherDashboardViewModel: ObservableObject {
         connectionManager?.sendDisconnectCommand(for: student)
     }
 
-    func startClass() {
-        connectionManager?.startClass()
+    func startClass(at date: Date) {
+        connectionManager?.startClass(at: date)
     }
 }
 


### PR DESCRIPTION
## Summary
- allow teachers to schedule class start times via popover
- show a full-screen countdown overlay on the server until class begins
- extend interaction model to support countdown content

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d6ba7bb88321b6716fe1481f5d20