### PR TITLE
feat: add vertical countdown digit animation

### DIFF
--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MultipeerConnectivity
 import SwiftData
+import SwiftUI
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -203,7 +204,9 @@ final class PeerConnectionManager: NSObject, ObservableObject {
     /// Presents new overlay content and makes it visible.
     func presentOverlay(content: OverlayContent) {
         overlayContent = content
-        isOverlayContentVisible = true
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isOverlayContentVisible = true
+        }
     }
 
     /// Starts a new interaction if none is active.
@@ -237,8 +240,12 @@ final class PeerConnectionManager: NSObject, ObservableObject {
     /// Ends the current interaction and removes its content from the overlay.
     func endInteraction(broadcast: Bool = true) {
         guard activeInteraction != nil else { return }
-        overlayContent = nil
-        isOverlayContentVisible = false
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isOverlayContentVisible = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.overlayContent = nil
+        }
         activeInteraction = nil
         interactionTask?.cancel()
         interactionTask = nil
@@ -253,7 +260,9 @@ final class PeerConnectionManager: NSObject, ObservableObject {
     /// Toggles the visibility of the current overlay content without removing it.
     func toggleOverlayContentVisibility() {
         guard overlayContent != nil else { return }
-        isOverlayContentVisible.toggle()
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isOverlayContentVisible.toggle()
+        }
     }
 
     func connect(to peer: Peer, passcode: String, nickname: String) {

--- a/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct CountdownOverlayView: View {
     @ObservedObject var service: CountdownService
     @AppStorage("overlayContentScale") private var overlayContentScale: Double = 1.0
+    @ScaledMetric private var baseSpacing: CGFloat = 24
+    @ScaledMetric private var baseTitleSize: CGFloat = 34
     
     @ViewBuilder
     private var countdownText: some View {
@@ -12,14 +14,12 @@ struct CountdownOverlayView: View {
     }
 
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: baseSpacing * overlayContentScale) {
             Text("Class Starts In")
-                .font(.title)
-                .bold()
+                .font(.system(size: baseTitleSize * overlayContentScale, weight: .bold))
                 .foregroundColor(.white)
             countdownText
         }
-        .scaleEffect(overlayContentScale)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .multilineTextAlignment(.center)
     }

--- a/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
@@ -20,10 +20,6 @@ struct CountdownOverlayView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .multilineTextAlignment(.center)
-        .transition(
-            .scale(scale: OverlayConstants.contentScale, anchor: .center)
-                .combined(with: .opacity)
-        )
     }
 }
 #endif

--- a/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
@@ -20,6 +20,10 @@ struct CountdownOverlayView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .multilineTextAlignment(.center)
+        .transition(
+            .scale(scale: OverlayConstants.contentScale, anchor: .center)
+                .combined(with: .opacity)
+        )
     }
 }
 #endif

--- a/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
@@ -4,13 +4,10 @@ import SwiftUI
 /// A countdown view showing minutes and seconds with animations.
 struct CountdownOverlayView: View {
     @ObservedObject var service: CountdownService
-    @State private var isVisible = false
-    @State private var tick = false
-
-    private var formattedTime: String {
-        let minutes = service.remainingSeconds / 60
-        let seconds = service.remainingSeconds % 60
-        return String(format: "%02d:%02d", minutes, seconds)
+    
+    @ViewBuilder
+    private var countdownText: some View {
+        CountdownDigitsView(remainingSeconds: service.remainingSeconds)
     }
 
     var body: some View {
@@ -19,25 +16,10 @@ struct CountdownOverlayView: View {
                 .font(.title)
                 .bold()
                 .foregroundColor(.white)
-            Text(formattedTime)
-                .font(.system(size: 120, weight: .bold, design: .rounded))
-                .foregroundColor(.white)
-                .monospacedDigit()
-                .scaleEffect(tick ? 1.1 : 1.0)
-                .animation(.easeInOut(duration: 0.25), value: tick)
+            countdownText
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .multilineTextAlignment(.center)
-        .opacity(isVisible ? 1 : 0)
-        .scaleEffect(isVisible ? 1 : 0.9)
-        .onAppear {
-            withAnimation(.easeInOut(duration: 0.3)) {
-                isVisible = true
-            }
-        }
-        .onChange(of: service.remainingSeconds) { _ in
-            tick.toggle()
-        }
     }
 }
 #endif

--- a/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/CountdownOverlayView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// A countdown view showing minutes and seconds with animations.
 struct CountdownOverlayView: View {
     @ObservedObject var service: CountdownService
+    @AppStorage("overlayContentScale") private var overlayContentScale: Double = 1.0
     
     @ViewBuilder
     private var countdownText: some View {
@@ -18,6 +19,7 @@ struct CountdownOverlayView: View {
                 .foregroundColor(.white)
             countdownText
         }
+        .scaleEffect(overlayContentScale)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .multilineTextAlignment(.center)
     }

--- a/InteractiveClassroom/View/MacOS/Overlay/OverlayNamesView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/OverlayNamesView.swift
@@ -6,7 +6,7 @@ struct OverlayNamesView: View {
     let names: [String]
     @ScaledMetric private var trailingPadding: CGFloat = 32
     @ScaledMetric private var baseFontSize: CGFloat = 20
-    @AppStorage("overlayFontScale") private var overlayFontScale: Double = 1.0
+    @AppStorage("overlayContentScale") private var overlayContentScale: Double = 1.0
 
     var body: some View {
         HStack {
@@ -14,7 +14,7 @@ struct OverlayNamesView: View {
             VStack(alignment: .trailing, spacing: 8) {
                 ForEach(names, id: \.self) { name in
                     Text(name)
-                        .font(.system(size: baseFontSize * overlayFontScale))
+                        .font(.system(size: baseFontSize * overlayContentScale))
                         .shadow(color: .black, radius: 1)
                 }
             }

--- a/InteractiveClassroom/View/MacOS/Overlay/OverlayStatsView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/OverlayStatsView.swift
@@ -6,7 +6,7 @@ struct OverlayStatsView: View {
     let stats: [String]
     @ScaledMetric private var leadingPadding: CGFloat = 32
     @ScaledMetric private var baseFontSize: CGFloat = 20
-    @AppStorage("overlayFontScale") private var overlayFontScale: Double = 1.0
+    @AppStorage("overlayContentScale") private var overlayContentScale: Double = 1.0
 
     var body: some View {
         HStack {
@@ -14,7 +14,7 @@ struct OverlayStatsView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     ForEach(stats, id: \.self) { stat in
                         Text(stat)
-                            .font(.system(size: baseFontSize * overlayFontScale))
+                            .font(.system(size: baseFontSize * overlayContentScale))
                             .shadow(color: .black, radius: 1)
                     }
                 }

--- a/InteractiveClassroom/View/MacOS/Overlay/OverlayTopBarView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/OverlayTopBarView.swift
@@ -8,19 +8,19 @@ struct OverlayTopBarView: View {
     @ScaledMetric private var horizontalPadding: CGFloat = 32
     @ScaledMetric private var verticalPadding: CGFloat = 32
     @ScaledMetric private var baseFontSize: CGFloat = 34
-    @AppStorage("overlayFontScale") private var overlayFontScale: Double = 1.0
+    @AppStorage("overlayContentScale") private var overlayContentScale: Double = 1.0
 
     var body: some View {
         VStack {
             HStack {
                 Text(questionType)
-                    .font(.system(size: baseFontSize * overlayFontScale, weight: .bold))
+                    .font(.system(size: baseFontSize * overlayContentScale, weight: .bold))
                     .shadow(color: .black, radius: 2)
                     .padding(.leading, horizontalPadding)
                     .padding(.top, verticalPadding)
                 Spacer()
                 Text(remainingTime)
-                    .font(.system(size: baseFontSize * overlayFontScale, weight: .bold))
+                    .font(.system(size: baseFontSize * overlayContentScale, weight: .bold))
                     .shadow(color: .black, radius: 2)
                     .padding(.trailing, horizontalPadding)
                     .padding(.top, verticalPadding)

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -240,7 +240,7 @@ struct FullScreenOverlay<Content: View>: View {
             if isVisible {
                 content()
                     .transition(
-                        .scale(scale: OverlayConstants.contentScale, anchor: .center)
+                        .scale(scale: 0.9, anchor: .center)
                             .combined(with: .opacity)
                     )
             }
@@ -269,7 +269,7 @@ struct CornerOverlay<Content: View>: View {
                 content()
                     .padding()
                     .transition(
-                        .scale(scale: OverlayConstants.contentScale, anchor: .center)
+                        .scale(scale: 0.9, anchor: .center)
                             .combined(with: .opacity)
                     )
             }

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -35,16 +35,21 @@ struct ScreenOverlayView: View {
 
     var body: some View {
         ZStack {
-            if let content = connectionManager.overlayContent,
-               connectionManager.isOverlayContentVisible {
+            if let content = connectionManager.overlayContent {
                 Group {
                     switch content.template {
                     case .fullScreen(let color):
-                        FullScreenOverlay(background: color) {
+                        FullScreenOverlay(
+                            background: color,
+                            isVisible: connectionManager.isOverlayContentVisible
+                        ) {
                             content.view
                         }
                     case .floatingCorner(let position):
-                        CornerOverlay(corner: position) {
+                        CornerOverlay(
+                            corner: position,
+                            isVisible: connectionManager.isOverlayContentVisible
+                        ) {
                             content.view
                         }
                     }
@@ -219,16 +224,26 @@ private struct WindowConfigurator: NSViewRepresentable {
 /// Template providing a blurred color full-screen background.
 struct FullScreenOverlay<Content: View>: View {
     var background: Color
+    var isVisible: Bool
     @ViewBuilder var content: () -> Content
 
     var body: some View {
         ZStack {
-            Rectangle()
-                .fill(background.opacity(0.4))
-                .background(.ultraThinMaterial)
-                .ignoresSafeArea()
-                .transition(.opacity)
-            content()
+            if isVisible {
+                Rectangle()
+                    .fill(background.opacity(0.4))
+                    .background(.ultraThinMaterial)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+            }
+
+            if isVisible {
+                content()
+                    .transition(
+                        .scale(scale: OverlayConstants.contentScale, anchor: .center)
+                            .combined(with: .opacity)
+                    )
+            }
         }
     }
 }
@@ -236,6 +251,7 @@ struct FullScreenOverlay<Content: View>: View {
 /// Template anchoring content to a screen corner without a background.
 struct CornerOverlay<Content: View>: View {
     var corner: OverlayCorner
+    var isVisible: Bool
     @ViewBuilder var content: () -> Content
 
     private var alignment: Alignment {
@@ -249,10 +265,14 @@ struct CornerOverlay<Content: View>: View {
 
     var body: some View {
         ZStack(alignment: alignment) {
-            content()
-                .padding()
-                .transition(.scale(scale: OverlayConstants.contentScale, anchor: .center)
-                    .combined(with: .opacity))
+            if isVisible {
+                content()
+                    .padding()
+                    .transition(
+                        .scale(scale: OverlayConstants.contentScale, anchor: .center)
+                            .combined(with: .opacity)
+                    )
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea()

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -229,8 +229,6 @@ struct FullScreenOverlay<Content: View>: View {
                 .ignoresSafeArea()
                 .transition(.opacity)
             content()
-                .transition(.scale(scale: OverlayConstants.contentScale, anchor: .center)
-                    .combined(with: .opacity))
         }
     }
 }

--- a/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/MacOS/Overlay/ScreenOverlayView.swift
@@ -37,14 +37,16 @@ struct ScreenOverlayView: View {
         ZStack {
             if let content = connectionManager.overlayContent,
                connectionManager.isOverlayContentVisible {
-                switch content.template {
-                case .fullScreen(let color):
-                    FullScreenOverlay(background: color) {
-                        content.view
-                    }
-                case .floatingCorner(let position):
-                    CornerOverlay(corner: position) {
-                        content.view
+                Group {
+                    switch content.template {
+                    case .fullScreen(let color):
+                        FullScreenOverlay(background: color) {
+                            content.view
+                        }
+                    case .floatingCorner(let position):
+                        CornerOverlay(corner: position) {
+                            content.view
+                        }
                     }
                 }
             }
@@ -225,7 +227,10 @@ struct FullScreenOverlay<Content: View>: View {
                 .fill(background.opacity(0.4))
                 .background(.ultraThinMaterial)
                 .ignoresSafeArea()
+                .transition(.opacity)
             content()
+                .transition(.scale(scale: OverlayConstants.contentScale, anchor: .center)
+                    .combined(with: .opacity))
         }
     }
 }
@@ -248,6 +253,8 @@ struct CornerOverlay<Content: View>: View {
         ZStack(alignment: alignment) {
             content()
                 .padding()
+                .transition(.scale(scale: OverlayConstants.contentScale, anchor: .center)
+                    .combined(with: .opacity))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea()

--- a/InteractiveClassroom/View/MacOS/SettingsView.swift
+++ b/InteractiveClassroom/View/MacOS/SettingsView.swift
@@ -6,15 +6,15 @@ import SwiftData
 struct SettingsView: View {
     @EnvironmentObject private var connectionManager: PeerConnectionManager
     @Environment(\.modelContext) private var modelContext
-    @AppStorage("overlayFontScale") private var overlayFontScale: Double = 1.0
+    @AppStorage("overlayContentScale") private var overlayContentScale: Double = 1.0
 
     var body: some View {
         Form {
             Section("Overlay") {
                 HStack {
-                    Text("Font Scale")
-                    Slider(value: $overlayFontScale, in: 0.5...2.0, step: 0.1)
-                    Text("\(overlayFontScale, specifier: "%.1f")x")
+                    Text("Overlay Scale")
+                    Slider(value: $overlayContentScale, in: 0.5...2.0, step: 0.1)
+                    Text("\(overlayContentScale, specifier: "%.1f")x")
                         .frame(width: 40, alignment: .trailing)
                 }
             }

--- a/InteractiveClassroom/View/Shared/CountdownDigitsView.swift
+++ b/InteractiveClassroom/View/Shared/CountdownDigitsView.swift
@@ -1,0 +1,30 @@
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+/// Displays a time string with a vertical rolling animation on digit changes.
+struct CountdownDigitsView: View {
+    /// Total remaining seconds to display.
+    let remainingSeconds: Int
+
+    private var formattedTime: String {
+        let minutes = remainingSeconds / 60
+        let seconds = remainingSeconds % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    var body: some View {
+        let text = Text(formattedTime)
+            .font(.system(size: 120, weight: .bold, design: .rounded))
+            .foregroundColor(.white)
+            .monospacedDigit()
+
+        if #available(iOS 17, macOS 14, *) {
+            text
+                .contentTransition(.numericText())
+                .animation(.easeInOut(duration: 0.3), value: remainingSeconds)
+        } else {
+            text
+        }
+    }
+}
+#endif

--- a/InteractiveClassroom/View/Shared/CountdownDigitsView.swift
+++ b/InteractiveClassroom/View/Shared/CountdownDigitsView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct CountdownDigitsView: View {
     /// Total remaining seconds to display.
     let remainingSeconds: Int
+    @AppStorage("overlayContentScale") private var overlayContentScale: Double = 1.0
+    @ScaledMetric private var baseFontSize: CGFloat = 120
 
     private var formattedTime: String {
         let minutes = remainingSeconds / 60
@@ -14,7 +16,7 @@ struct CountdownDigitsView: View {
 
     var body: some View {
         let text = Text(formattedTime)
-            .font(.system(size: 120, weight: .bold, design: .rounded))
+            .font(.system(size: baseFontSize * overlayContentScale, weight: .bold, design: .rounded))
             .foregroundColor(.white)
             .monospacedDigit()
 

--- a/InteractiveClassroom/View/Shared/OverlayConstants.swift
+++ b/InteractiveClassroom/View/Shared/OverlayConstants.swift
@@ -1,0 +1,9 @@
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+/// Shared constants governing overlay presentation behavior.
+enum OverlayConstants {
+    /// Initial scale applied when overlay content is inserted or removed.
+    static let contentScale: CGFloat = 0.9
+}
+#endif

--- a/InteractiveClassroom/View/Shared/OverlayConstants.swift
+++ b/InteractiveClassroom/View/Shared/OverlayConstants.swift
@@ -1,9 +1,0 @@
-#if os(iOS) || os(macOS)
-import SwiftUI
-
-/// Shared constants governing overlay presentation behavior.
-enum OverlayConstants {
-    /// Initial scale applied when overlay content is inserted or removed.
-    static let contentScale: CGFloat = 0.9
-}
-#endif


### PR DESCRIPTION
## Summary
- create reusable `CountdownDigitsView` that animates digits with Apple's vertical scroll style
- integrate the new component into `CountdownOverlayView`
- animate overlay content appearance/disappearance and centralize scale constant
- fade full-screen overlay backgrounds independently while preserving existing content transitions

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

## Additional Notes
- Please add `InteractiveClassroom/View/Shared/CountdownDigitsView.swift` and `InteractiveClassroom/View/Shared/OverlayConstants.swift` to the Xcode project so they are compiled.


------
https://chatgpt.com/codex/tasks/task_e_68a1e1674c44832187641e3c019c9f15