### PR TITLE
Refactor overlay handling into dedicated service

### DIFF
--- a/InteractiveClassroom/Model/Interaction/InteractionHandling.swift
+++ b/InteractiveClassroom/Model/Interaction/InteractionHandling.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol InteractionHandling: AnyObject {
+    func startInteraction(_ request: InteractionRequest, broadcast: Bool)
+    func endInteraction(broadcast: Bool)
+}

--- a/InteractiveClassroom/Model/Interaction/InteractionService.swift
+++ b/InteractiveClassroom/Model/Interaction/InteractionService.swift
@@ -10,33 +10,76 @@ final class InteractionService: ObservableObject {
     @Published var countdownService: CountdownService?
 
     private let manager: PeerConnectionManager
-    private var cancellables: Set<AnyCancellable> = []
+    private var interactionTask: Task<Void, Never>?
 
     init(manager: PeerConnectionManager) {
         self.manager = manager
+        self.manager.interactionHandler = self
+    }
 
-        manager.$overlayContent
-            .receive(on: RunLoop.main)
-            .sink { [weak self] in self?.overlayContent = $0 }
-            .store(in: &cancellables)
-        manager.$isOverlayContentVisible
-            .receive(on: RunLoop.main)
-            .sink { [weak self] in self?.isOverlayContentVisible = $0 }
-            .store(in: &cancellables)
-        manager.$activeInteraction
-            .receive(on: RunLoop.main)
-            .sink { [weak self] in self?.activeInteraction = $0 }
-            .store(in: &cancellables)
-        manager.$countdownService
-            .receive(on: RunLoop.main)
-            .sink { [weak self] in self?.countdownService = $0 }
-            .store(in: &cancellables)
+    var overlayHasContent: Bool { overlayContent != nil }
+
+    // MARK: - Overlay Management
+    private func presentOverlay(_ content: OverlayContent) {
+        overlayContent = content
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isOverlayContentVisible = true
+        }
+    }
+
+    func toggleOverlayVisibility() {
+        guard overlayContent != nil else { return }
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isOverlayContentVisible.toggle()
+        }
     }
 
     // MARK: - Interaction Controls
+    func startInteraction(_ request: InteractionRequest, broadcast: Bool = true) {
+        guard activeInteraction == nil else { return }
+        let interaction = Interaction(request: request)
+        activeInteraction = interaction
 
-    func presentOverlay(_ content: OverlayContent) { manager.presentOverlay(content: content) }
-    func toggleOverlayVisibility() { manager.toggleOverlayContentVisibility() }
-    func startInteraction(_ request: InteractionRequest, broadcast: Bool = true) { manager.startInteraction(request, broadcast: broadcast) }
-    func endInteraction(broadcast: Bool = true) { manager.endInteraction(broadcast: broadcast) }
+        if case .countdown = request.content,
+           let seconds = request.lifecycle.secondsValue {
+            let service = CountdownService(seconds: seconds)
+            countdownService = service
+            presentOverlay(request.makeOverlay(countdownService: service))
+            service.start { [weak self] in
+                self?.endInteraction()
+            }
+        } else {
+            presentOverlay(request.makeOverlay())
+            if case let .finite(seconds) = request.lifecycle {
+                interactionTask = Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
+                    self?.endInteraction()
+                }
+            }
+        }
+
+        if broadcast {
+            manager.broadcastStartInteraction(request)
+        }
+    }
+
+    func endInteraction(broadcast: Bool = true) {
+        guard activeInteraction != nil else { return }
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isOverlayContentVisible = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.overlayContent = nil
+        }
+        activeInteraction = nil
+        interactionTask?.cancel()
+        interactionTask = nil
+        countdownService?.stop()
+        countdownService = nil
+        if broadcast {
+            manager.broadcastStopInteraction()
+        }
+    }
 }
+
+extension InteractionService: InteractionHandling {}

--- a/InteractiveClassroom/Model/Interaction/InteractionService.swift
+++ b/InteractiveClassroom/Model/Interaction/InteractionService.swift
@@ -82,4 +82,4 @@ final class InteractionService: ObservableObject {
     }
 }
 
-extension InteractionService: InteractionHandling {}
+extension InteractionService: @preconcurrency InteractionHandling {}

--- a/InteractiveClassroom/Model/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnectionManager.swift
@@ -166,7 +166,7 @@ final class PeerConnectionManager: NSObject, ObservableObject {
 
     /// Ends the classroom session and disconnects all clients.
     func endClass() {
-        interactionHandler?.endInteraction()
+        interactionHandler?.endInteraction(broadcast: true)
         advertiser?.stopAdvertisingPeer()
         advertiser = nil
         if !sessions.isEmpty {


### PR DESCRIPTION
## Summary
- Extract overlay and interaction management from `PeerConnectionManager` into `InteractionService`
- Introduce `InteractionHandling` protocol and interaction broadcast helpers
- Delegate overlay lifecycle to `InteractionService` for clearer MVVM separation

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a27fd7eaac8321b4d7d0c40c828266