### PR TITLE
Offload message encoding and sending

### DIFF
--- a/InteractiveClassroom/Model/PeerConnection/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnection/PeerConnectionManager.swift
@@ -111,16 +111,28 @@ class PeerConnectionManager: NSObject, ObservableObject {
         self.init(modelContext: nil)
     }
 
-    func sendMessageToServer(_ message: Message) {
-        guard let server = connectedServer else { return }
-        if let data = try? JSONEncoder().encode(message) {
+    nonisolated func sendMessageToServer(_ message: Message) {
+        Task.detached(priority: .background) { [weak self] in
+            guard let self else { return }
+            guard let data = try? JSONEncoder().encode(message) else { return }
+            let context = await MainActor.run { () -> (MCPeerID?, MCSession) in
+                (self.connectedServer, self.session)
+            }
+            guard let server = context.0 else { return }
+            let session = context.1
             try? session.send(data, toPeers: [server], with: .reliable)
         }
     }
 
-    func forwardToClients(_ message: Message, excluding origin: MCPeerID? = nil) {
-        guard advertiser != nil else { return }
-        if let data = try? JSONEncoder().encode(message) {
+    nonisolated func forwardToClients(_ message: Message, excluding origin: MCPeerID? = nil) {
+        Task.detached(priority: .background) { [weak self] in
+            guard let self else { return }
+            guard let data = try? JSONEncoder().encode(message) else { return }
+            let context = await MainActor.run { () -> (MCNearbyServiceAdvertiser?, [MCPeerID: MCSession]) in
+                (self.advertiser, self.sessions)
+            }
+            guard context.0 != nil else { return }
+            let sessions = context.1
             for (peerID, sess) in sessions where peerID != origin {
                 if !sess.connectedPeers.isEmpty {
                     try? sess.send(data, toPeers: sess.connectedPeers, with: .reliable)


### PR DESCRIPTION
## Summary
- Encode messages off the main thread and send asynchronously to keep the UI responsive
- Forward client messages in a detached task, avoiding main-thread blocking

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a296e4f1648321b79b00adde3addbc