### PR TITLE
Refactor macOS menu bar into dedicated scene and view model

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -48,40 +48,12 @@ struct InteractiveClassroomApp: App {
 
     var body: some Scene {
 #if os(macOS)
-        MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
-            MenuBarView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-        }
-        .modelContainer(container)
-        Settings {
-            SettingsView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-        }
-        .modelContainer(container)
-        WindowGroup(id: "courseSelection") {
-            CourseSelectionView()
-                .environmentObject(courseSessionService)
-                .environmentObject(pairingService)
-        }
-        .modelContainer(container)
-        WindowGroup(id: "clients") {
-            ClientsListView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-        }
-        .modelContainer(container)
-        WindowGroup(id: "courseManager") {
-            CourseManagerView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-        }
-        .modelContainer(container)
+        MenuBarScene(
+            pairingService: pairingService,
+            courseSessionService: courseSessionService,
+            interactionService: interactionService,
+            container: container
+        )
 #else
         WindowGroup {
             ContentView()

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -45,10 +45,13 @@ struct MenuBarScene: Scene {
                 .environmentObject(interactionService)
         }
         .modelContainer(container)
-        WindowGroup(id: "courseSelection") {
-            CourseSelectionView()
-                .environmentObject(courseSessionService)
-                .environmentObject(pairingService)
+        WindowGroup("Select Course and Lesson", id: "courseSelection") {
+            CourseSelectionView(
+                viewModel: OpenClassroomViewModel(
+                    courseSessionService: courseSessionService,
+                    pairingService: pairingService
+                )
+            )
         }
         .modelContainer(container)
         WindowGroup(id: "clients") {

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -1,0 +1,49 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+/// macOS-specific scenes presented from the menu bar.
+struct MenuBarScene: Scene {
+    @ObservedObject var pairingService: PairingService
+    @ObservedObject var courseSessionService: CourseSessionService
+    @ObservedObject var interactionService: InteractionService
+    let container: ModelContainer
+
+    var body: some Scene {
+        MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
+            MenuBarView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+        }
+        .modelContainer(container)
+        Settings {
+            SettingsView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+        }
+        .modelContainer(container)
+        WindowGroup(id: "courseSelection") {
+            CourseSelectionView()
+                .environmentObject(courseSessionService)
+                .environmentObject(pairingService)
+        }
+        .modelContainer(container)
+        WindowGroup(id: "clients") {
+            ClientsListView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+        }
+        .modelContainer(container)
+        WindowGroup(id: "courseManager") {
+            CourseManagerView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+        }
+        .modelContainer(container)
+    }
+}
+#endif

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -8,6 +8,26 @@ struct MenuBarScene: Scene {
     @ObservedObject var courseSessionService: CourseSessionService
     @ObservedObject var interactionService: InteractionService
     let container: ModelContainer
+    @StateObject private var overlayManager: OverlayWindowManager
+
+    init(
+        pairingService: PairingService,
+        courseSessionService: CourseSessionService,
+        interactionService: InteractionService,
+        container: ModelContainer
+    ) {
+        self.pairingService = pairingService
+        self.courseSessionService = courseSessionService
+        self.interactionService = interactionService
+        self.container = container
+        _overlayManager = StateObject(
+            wrappedValue: OverlayWindowManager(
+                pairingService: pairingService,
+                courseSessionService: courseSessionService,
+                interactionService: interactionService
+            )
+        )
+    }
 
     var body: some Scene {
         MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
@@ -15,6 +35,7 @@ struct MenuBarScene: Scene {
                 .environmentObject(pairingService)
                 .environmentObject(courseSessionService)
                 .environmentObject(interactionService)
+                .environmentObject(overlayManager)
         }
         .modelContainer(container)
         Settings {

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -25,6 +25,7 @@ struct MenuBarView: View {
                 }
             } else {
                 Button("End Class") {
+                    viewModel.closeOverlay()
                     courseSessionService.endClass()
                 }
             }

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -28,6 +28,7 @@ struct MenuBarView: View {
                 Button("End Class") {
                     overlayManager.closeOverlay()
                     courseSessionService.endClass()
+                    viewModel.reloadMenuBar()
                 }
             }
             Button("Clients") {
@@ -50,6 +51,7 @@ struct MenuBarView: View {
                 NSApp.terminate(nil)
             }
         }
+        .id(viewModel.reloadToken)
         .onChange(of: pairingService.teacherCode) { code in
             if code != nil {
                 overlayManager.openOverlay(
@@ -59,6 +61,7 @@ struct MenuBarView: View {
                 )
             } else {
                 overlayManager.closeOverlay()
+                viewModel.reloadMenuBar()
             }
         }
     }

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -9,6 +9,7 @@ struct MenuBarView: View {
     @EnvironmentObject private var interactionService: InteractionService
     @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = MenuBarViewModel()
+    @StateObject private var overlayManager = OverlayWindowManager()
 
     var body: some View {
         Group {
@@ -25,7 +26,7 @@ struct MenuBarView: View {
                 }
             } else {
                 Button("End Class") {
-                    viewModel.closeOverlay()
+                    overlayManager.closeOverlay()
                     courseSessionService.endClass()
                 }
             }
@@ -51,13 +52,13 @@ struct MenuBarView: View {
         }
         .onChange(of: pairingService.teacherCode) { code in
             if code != nil {
-                viewModel.openOverlay(
+                overlayManager.openOverlay(
                     pairingService: pairingService,
                     courseSessionService: courseSessionService,
                     interactionService: interactionService
                 )
             } else {
-                viewModel.closeOverlay()
+                overlayManager.closeOverlay()
             }
         }
     }

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -7,9 +7,9 @@ struct MenuBarView: View {
     @EnvironmentObject private var pairingService: PairingService
     @EnvironmentObject private var courseSessionService: CourseSessionService
     @EnvironmentObject private var interactionService: InteractionService
+    @EnvironmentObject private var overlayManager: OverlayWindowManager
     @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = MenuBarViewModel()
-    @StateObject private var overlayManager = OverlayWindowManager()
 
     var body: some View {
         Group {
@@ -52,27 +52,21 @@ struct MenuBarView: View {
             }
         }
         .id(viewModel.reloadToken)
-        .onChange(of: pairingService.teacherCode) { code in
-            if code != nil {
-                overlayManager.openOverlay(
-                    pairingService: pairingService,
-                    courseSessionService: courseSessionService,
-                    interactionService: interactionService
-                )
-            } else {
-                overlayManager.closeOverlay()
-                viewModel.reloadMenuBar()
-            }
-        }
     }
 }
 #Preview {
     let pairing = PairingService()
     let interaction = InteractionService(manager: pairing)
     let courseService = CourseSessionService(manager: pairing, interactionService: interaction)
+    let overlayManager = OverlayWindowManager(
+        pairingService: pairing,
+        courseSessionService: courseService,
+        interactionService: interaction
+    )
     return MenuBarView()
         .environmentObject(pairing)
         .environmentObject(courseService)
         .environmentObject(interaction)
+        .environmentObject(overlayManager)
 }
 #endif

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -25,10 +25,7 @@ struct MenuBarView: View {
                 }
             } else {
                 Button("End Class") {
-                    interactionService.endClass()
-                    pairingService.currentCourse = nil
-                    pairingService.currentLesson = nil
-                    viewModel.closeOverlay()
+                    courseSessionService.endClass()
                 }
             }
             Button("Clients") {

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -12,6 +12,9 @@ struct ScreenOverlayView: View {
     @EnvironmentObject private var interactionService: InteractionService
     @Environment(\.openWindow) private var openWindow
     @State private var isToolbarFolded = false
+    #if os(macOS)
+    @EnvironmentObject private var overlayManager: OverlayWindowManager
+    #endif
 
     #if os(macOS)
     /// Opens or brings to front the window identified by `id`.
@@ -30,6 +33,9 @@ struct ScreenOverlayView: View {
     #endif
 
     private func endCurrentClass() {
+        #if os(macOS)
+        overlayManager.closeOverlay()
+        #endif
         courseSessionService.endClass()
     }
 

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -204,9 +204,9 @@ private struct WindowConfigurator: NSViewRepresentable {
             super.viewDidMoveToWindow()
             guard let window = window else { return }
             window.identifier = NSUserInterfaceItemIdentifier("overlay")
-            // Place the overlay below the system menu bar so status items remain
+            // Place the overlay just below the system menu bar so status items remain
             // interactive while still covering the rest of the screen.
-            window.level = .mainMenu
+            window.level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue - 1)
             window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
             if let screenFrame = NSScreen.main?.frame {
                 window.setFrame(screenFrame, display: true)

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -187,39 +187,9 @@ struct ScreenOverlayView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.clear)
         .ignoresSafeArea(.all)
-        #if os(macOS)
-        .background(WindowConfigurator())
-        #endif
     }
 }
 
-#if os(macOS)
-/// Helper view configuring the hosting window for a full-screen overlay.
-private struct WindowConfigurator: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView { ConfigurableView() }
-    func updateNSView(_ nsView: NSView, context: Context) {}
-
-    private final class ConfigurableView: NSView {
-        override func viewDidMoveToWindow() {
-            super.viewDidMoveToWindow()
-            guard let window = window else { return }
-            window.identifier = NSUserInterfaceItemIdentifier("overlay")
-            // Place the overlay just below the system menu bar so status items remain
-            // interactive while still covering the rest of the screen.
-            window.level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue - 1)
-            window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
-            if let screenFrame = NSScreen.main?.frame {
-                window.setFrame(screenFrame, display: true)
-                window.contentView?.frame = screenFrame
-            }
-            window.styleMask = [.borderless]
-            window.isOpaque = false
-            window.backgroundColor = .clear
-            window.orderFrontRegardless()
-        }
-    }
-}
-#endif
 
 /// Template providing a blurred color full-screen background.
 struct FullScreenOverlay<Content: View>: View {

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -31,9 +31,10 @@ final class MenuBarViewModel: ObservableObject {
 
     /// Closes any existing overlay windows and restores normal presentation.
     func closeOverlay() {
-        overlayWindow?.close()
+        let overlayWindows = NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }
+        guard !overlayWindows.isEmpty || overlayWindow != nil else { return }
+        overlayWindows.forEach { $0.close() }
         overlayWindow = nil
-        NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }.forEach { $0.close() }
         NSApp.presentationOptions = originalPresentationOptions
     }
 

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -1,0 +1,48 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+/// Handles macOS menu bar window management.
+@MainActor
+final class MenuBarViewModel: ObservableObject {
+    private var overlayWindow: NSWindow?
+
+    /// Presents the full-screen overlay window.
+    func openOverlay(
+        pairingService: PairingService,
+        courseSessionService: CourseSessionService,
+        interactionService: InteractionService
+    ) {
+        closeOverlay()
+        NSApp.presentationOptions = [.autoHideDock, .autoHideMenuBar]
+        let controller = NSHostingController(
+            rootView: ScreenOverlayView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+        )
+        let window = NSWindow(contentViewController: controller)
+        window.isReleasedWhenClosed = false
+        window.makeKeyAndOrderFront(nil)
+        overlayWindow = window
+    }
+
+    /// Closes any existing overlay windows and restores normal presentation.
+    func closeOverlay() {
+        overlayWindow?.close()
+        overlayWindow = nil
+        NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }.forEach { $0.close() }
+        NSApp.presentationOptions = []
+    }
+
+    /// Opens a window identified by `id` if one isn't already visible.
+    /// If the window exists, it is brought to the front instead of creating a duplicate.
+    func openWindowIfNeeded(id: String, openWindow: OpenWindowAction) {
+        if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == id }) {
+            window.makeKeyAndOrderFront(nil)
+        } else {
+            openWindow(id: id)
+        }
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -2,43 +2,9 @@
 import SwiftUI
 import AppKit
 
-/// Handles macOS menu bar window management.
+/// Handles macOS menu bar window interactions.
 @MainActor
 final class MenuBarViewModel: ObservableObject {
-    private var overlayWindow: NSWindow?
-    private var originalPresentationOptions: NSApplication.PresentationOptions = []
-
-    /// Presents the full-screen overlay window.
-    func openOverlay(
-        pairingService: PairingService,
-        courseSessionService: CourseSessionService,
-        interactionService: InteractionService
-    ) {
-        closeOverlay()
-        originalPresentationOptions = NSApp.presentationOptions
-        NSApp.presentationOptions = originalPresentationOptions.union([.autoHideDock, .autoHideMenuBar])
-        let controller = NSHostingController(
-            rootView: ScreenOverlayView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-        )
-        let window = NSWindow(contentViewController: controller)
-        configureOverlayWindow(window)
-        window.makeKeyAndOrderFront(nil)
-        overlayWindow = window
-    }
-
-    /// Closes any existing overlay windows and restores normal presentation.
-    func closeOverlay() {
-        overlayWindow?.close()
-        let overlayWindows = NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }
-        guard !overlayWindows.isEmpty || overlayWindow != nil else { return }
-        overlayWindows.forEach { $0.close() }
-        overlayWindow = nil
-        NSApp.presentationOptions = originalPresentationOptions
-    }
-
     /// Opens a window identified by `id` if one isn't already visible.
     /// If the window exists, it is brought to the front instead of creating a duplicate.
     func openWindowIfNeeded(id: String, openWindow: OpenWindowAction) {
@@ -47,22 +13,6 @@ final class MenuBarViewModel: ObservableObject {
         } else {
             openWindow(id: id)
         }
-    }
-
-    /// Applies identifier and screen configuration to the overlay window.
-    private func configureOverlayWindow(_ window: NSWindow) {
-        window.identifier = NSUserInterfaceItemIdentifier("overlay")
-        window.level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue - 1)
-        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
-        if let screenFrame = NSScreen.main?.frame {
-            window.setFrame(screenFrame, display: true)
-            window.contentView?.frame = screenFrame
-        }
-        window.styleMask = [.borderless]
-        window.isOpaque = false
-        window.backgroundColor = .clear
-        window.isReleasedWhenClosed = false
-        window.orderFrontRegardless()
     }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -24,13 +24,14 @@ final class MenuBarViewModel: ObservableObject {
                 .environmentObject(interactionService)
         )
         let window = NSWindow(contentViewController: controller)
-        window.isReleasedWhenClosed = false
+        configureOverlayWindow(window)
         window.makeKeyAndOrderFront(nil)
         overlayWindow = window
     }
 
     /// Closes any existing overlay windows and restores normal presentation.
     func closeOverlay() {
+        overlayWindow?.close()
         let overlayWindows = NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }
         guard !overlayWindows.isEmpty || overlayWindow != nil else { return }
         overlayWindows.forEach { $0.close() }
@@ -46,6 +47,22 @@ final class MenuBarViewModel: ObservableObject {
         } else {
             openWindow(id: id)
         }
+    }
+
+    /// Applies identifier and screen configuration to the overlay window.
+    private func configureOverlayWindow(_ window: NSWindow) {
+        window.identifier = NSUserInterfaceItemIdentifier("overlay")
+        window.level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue - 1)
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        if let screenFrame = NSScreen.main?.frame {
+            window.setFrame(screenFrame, display: true)
+            window.contentView?.frame = screenFrame
+        }
+        window.styleMask = [.borderless]
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.isReleasedWhenClosed = false
+        window.orderFrontRegardless()
     }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -5,6 +5,9 @@ import AppKit
 /// Handles macOS menu bar window interactions.
 @MainActor
 final class MenuBarViewModel: ObservableObject {
+    /// Token used to force the menu bar view to refresh when changed.
+    @Published var reloadToken = UUID()
+
     /// Opens a window identified by `id` if one isn't already visible.
     /// If the window exists, it is brought to the front instead of creating a duplicate.
     func openWindowIfNeeded(id: String, openWindow: OpenWindowAction) {
@@ -13,6 +16,11 @@ final class MenuBarViewModel: ObservableObject {
         } else {
             openWindow(id: id)
         }
+    }
+
+    /// Generates a new reload token causing any view referencing it to rebuild.
+    func reloadMenuBar() {
+        reloadToken = UUID()
     }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -6,6 +6,7 @@ import AppKit
 @MainActor
 final class MenuBarViewModel: ObservableObject {
     private var overlayWindow: NSWindow?
+    private var originalPresentationOptions: NSApplication.PresentationOptions = []
 
     /// Presents the full-screen overlay window.
     func openOverlay(
@@ -14,7 +15,8 @@ final class MenuBarViewModel: ObservableObject {
         interactionService: InteractionService
     ) {
         closeOverlay()
-        NSApp.presentationOptions = [.autoHideDock, .autoHideMenuBar]
+        originalPresentationOptions = NSApp.presentationOptions
+        NSApp.presentationOptions = originalPresentationOptions.union([.autoHideDock, .autoHideMenuBar])
         let controller = NSHostingController(
             rootView: ScreenOverlayView()
                 .environmentObject(pairingService)
@@ -32,7 +34,7 @@ final class MenuBarViewModel: ObservableObject {
         overlayWindow?.close()
         overlayWindow = nil
         NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }.forEach { $0.close() }
-        NSApp.presentationOptions = []
+        NSApp.presentationOptions = originalPresentationOptions
     }
 
     /// Opens a window identified by `id` if one isn't already visible.

--- a/InteractiveClassroom/ViewModel/Server/OpenClassroomViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/OpenClassroomViewModel.swift
@@ -1,0 +1,37 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+/// View model for the course selection ("Open Classroom") window.
+@MainActor
+final class OpenClassroomViewModel: ObservableObject {
+    @Published var selectedCourse: Course?
+    @Published var selectedLesson: Lesson?
+
+    private let courseSessionService: CourseSessionService
+    private let pairingService: PairingService
+
+    init(courseSessionService: CourseSessionService, pairingService: PairingService) {
+        self.courseSessionService = courseSessionService
+        self.pairingService = pairingService
+    }
+
+    /// Lessons belonging to the selected course ordered by schedule.
+    var lessons: [Lesson] {
+        selectedCourse?.lessons.sorted { $0.scheduledAt < $1.scheduledAt } ?? []
+    }
+
+    /// Whether the "Open Classroom" action is currently available.
+    var canOpen: Bool {
+        selectedCourse != nil && selectedLesson != nil
+    }
+
+    /// Open the classroom using the selected course and lesson.
+    func openClassroom() {
+        guard let course = selectedCourse, let lesson = selectedLesson else { return }
+        courseSessionService.selectCourse(course)
+        courseSessionService.selectLesson(lesson)
+        pairingService.openClassroom()
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -16,7 +16,7 @@ final class OverlayWindowManager: ObservableObject {
     ) {
         closeOverlay()
         originalPresentationOptions = NSApp.presentationOptions
-        NSApp.setPresentationOptions(originalPresentationOptions.union([.autoHideDock, .autoHideMenuBar]))
+        NSApp.presentationOptions = originalPresentationOptions.union([.autoHideDock, .autoHideMenuBar])
         let controller = NSHostingController(
             rootView: ScreenOverlayView()
                 .environmentObject(pairingService)
@@ -36,7 +36,7 @@ final class OverlayWindowManager: ObservableObject {
         let overlayWindows = NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }
         overlayWindows.forEach { $0.orderOut(nil); $0.close() }
         overlayWindow = nil
-        NSApp.setPresentationOptions(originalPresentationOptions)
+        NSApp.presentationOptions = originalPresentationOptions
         NSApp.activate(ignoringOtherApps: true)
     }
 

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -80,7 +80,7 @@ final class OverlayWindowManager: ObservableObject {
         window.styleMask = [.borderless]
         window.isOpaque = false
         window.backgroundColor = .clear
-        window.isReleasedWhenClosed = false
+        window.isReleasedWhenClosed = true
     }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -25,7 +25,7 @@ final class OverlayWindowManager: ObservableObject {
         )
         let window = NSWindow(contentViewController: controller)
         configureOverlayWindow(window)
-        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
         overlayWindow = window
     }
 

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -43,9 +43,9 @@ final class OverlayWindowManager: ObservableObject {
         NSApp.presentationOptions = originalPresentationOptions.union([.autoHideDock, .autoHideMenuBar])
         let controller = NSHostingController(
             rootView: ScreenOverlayView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
+                .environmentObject(self.pairingService)
+                .environmentObject(self.courseSessionService)
+                .environmentObject(self.interactionService)
                 .environmentObject(self)
         )
         let window = NSWindow(contentViewController: controller)
@@ -107,12 +107,12 @@ final class OverlayWindowManager: ObservableObject {
         let controller = NSHostingController(
             rootView: CourseSelectionView(
                 viewModel: OpenClassroomViewModel(
-                    courseSessionService: courseSessionService,
-                    pairingService: pairingService
+                    courseSessionService: self.courseSessionService,
+                    pairingService: self.pairingService
                 )
             )
-            .environmentObject(courseSessionService)
-            .environmentObject(pairingService)
+            .environmentObject(self.courseSessionService)
+            .environmentObject(self.pairingService)
         )
         let window = NSWindow(contentViewController: controller)
         window.identifier = NSUserInterfaceItemIdentifier("courseSelection")

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -1,0 +1,58 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+/// Handles presentation of the full-screen overlay window.
+@MainActor
+final class OverlayWindowManager: ObservableObject {
+    private var overlayWindow: NSWindow?
+    private var originalPresentationOptions: NSApplication.PresentationOptions = []
+
+    /// Presents the overlay configured for full-screen display.
+    func openOverlay(
+        pairingService: PairingService,
+        courseSessionService: CourseSessionService,
+        interactionService: InteractionService
+    ) {
+        closeOverlay()
+        originalPresentationOptions = NSApp.presentationOptions
+        NSApp.setPresentationOptions(originalPresentationOptions.union([.autoHideDock, .autoHideMenuBar]))
+        let controller = NSHostingController(
+            rootView: ScreenOverlayView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+        )
+        let window = NSWindow(contentViewController: controller)
+        configureOverlayWindow(window)
+        window.makeKeyAndOrderFront(nil)
+        overlayWindow = window
+    }
+
+    /// Closes all overlay windows and restores the application's presentation options.
+    func closeOverlay() {
+        overlayWindow?.orderOut(nil)
+        overlayWindow?.close()
+        let overlayWindows = NSApp.windows.filter { $0.identifier?.rawValue == "overlay" }
+        overlayWindows.forEach { $0.orderOut(nil); $0.close() }
+        overlayWindow = nil
+        NSApp.setPresentationOptions(originalPresentationOptions)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    /// Applies identifier and screen configuration to the overlay window.
+    private func configureOverlayWindow(_ window: NSWindow) {
+        window.identifier = NSUserInterfaceItemIdentifier("overlay")
+        window.level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue - 1)
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        if let screenFrame = NSScreen.main?.frame {
+            window.setFrame(screenFrame, display: true)
+            window.contentView?.frame = screenFrame
+        }
+        window.styleMask = [.borderless]
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.isReleasedWhenClosed = false
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -105,13 +105,18 @@ final class OverlayWindowManager: ObservableObject {
         }
 
         let controller = NSHostingController(
-            rootView: CourseSelectionView()
-                .environmentObject(courseSessionService)
-                .environmentObject(pairingService)
+            rootView: CourseSelectionView(
+                viewModel: OpenClassroomViewModel(
+                    courseSessionService: courseSessionService,
+                    pairingService: pairingService
+                )
+            )
+            .environmentObject(courseSessionService)
+            .environmentObject(pairingService)
         )
         let window = NSWindow(contentViewController: controller)
         window.identifier = NSUserInterfaceItemIdentifier("courseSelection")
-        window.makeKeyAndOrderFront(nil)
+        window.makeKeyAndOrderFront(nil as Any?)
     }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -72,6 +72,7 @@ final class OverlayWindowManager: ObservableObject {
 
         overlayWindow = nil
         NSApp.presentationOptions = originalPresentationOptions
+        showCourseSelectionWindow()
         NSApp.activate(ignoringOtherApps: true)
         #if DEBUG
         // Assert that no overlay windows remain visible after teardown.
@@ -94,6 +95,23 @@ final class OverlayWindowManager: ObservableObject {
         // Avoid double free crashes by keeping the window alive until we
         // explicitly release our reference.
         window.isReleasedWhenClosed = false
+    }
+
+    /// Brings the course-selection window to the front, creating it if necessary.
+    private func showCourseSelectionWindow() {
+        if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "courseSelection" }) {
+            window.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        let controller = NSHostingController(
+            rootView: CourseSelectionView()
+                .environmentObject(courseSessionService)
+                .environmentObject(pairingService)
+        )
+        let window = NSWindow(contentViewController: controller)
+        window.identifier = NSUserInterfaceItemIdentifier("courseSelection")
+        window.makeKeyAndOrderFront(nil)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Encapsulate macOS menu bar scenes in `MenuBarScene` for modular menubar logic
- Introduce `MenuBarViewModel` to manage overlay and window actions
- Update `MenuBarView` and main app to use the new scene and view model

## Testing
- `swift build` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_68a2bc656310832192b3d2f6c55e0456