### PR TITLE
Resolve overlay layout interference and menu assertion

### DIFF
--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -28,7 +28,9 @@ struct MenuBarView: View {
                 Button("End Class") {
                     overlayManager.closeOverlay()
                     courseSessionService.endClass()
-                    viewModel.reloadMenuBar()
+                    DispatchQueue.main.async {
+                        viewModel.reloadMenuBar()
+                    }
                 }
             }
             Button("Clients") {

--- a/InteractiveClassroom/View/Server/Overlay/MenuBarPassthroughView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/MenuBarPassthroughView.swift
@@ -1,0 +1,15 @@
+#if os(macOS)
+import AppKit
+
+/// NSView that lets mouse events in the menu bar region fall through so that
+/// menu bar items remain clickable even when the overlay covers the screen.
+final class MenuBarPassthroughView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let menuBarHeight = NSStatusBar.system.thickness
+        if point.y >= bounds.height - menuBarHeight {
+            return nil
+        }
+        return super.hitTest(point)
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -11,7 +11,7 @@ final class OverlayWindowManager: ObservableObject {
     private let interactionService: InteractionService
 
     private var overlayWindow: NSWindow?
-    private var overlayHostingController: NSHostingController<ScreenOverlayView>?
+    private var overlayHostingController: NSHostingController<AnyView>?
     private var originalPresentationOptions: NSApplication.PresentationOptions = []
     private var cancellables: Set<AnyCancellable> = []
 
@@ -43,11 +43,13 @@ final class OverlayWindowManager: ObservableObject {
         originalPresentationOptions = NSApp.presentationOptions
         NSApp.presentationOptions = originalPresentationOptions.union([.autoHideDock, .autoHideMenuBar])
         let controller = NSHostingController(
-            rootView: ScreenOverlayView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-                .environmentObject(self)
+            rootView: AnyView(
+                ScreenOverlayView()
+                    .environmentObject(pairingService)
+                    .environmentObject(courseSessionService)
+                    .environmentObject(interactionService)
+                    .environmentObject(self)
+            )
         )
         overlayHostingController = controller
         let window = NSWindow()

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -41,7 +41,7 @@ final class OverlayWindowManager: ObservableObject {
     private func openOverlay() {
         closeOverlay()
         originalPresentationOptions = NSApp.presentationOptions
-        NSApp.presentationOptions = originalPresentationOptions.union([.autoHideDock, .autoHideMenuBar])
+        NSApp.presentationOptions = originalPresentationOptions.union([.autoHideDock])
         let controller = NSHostingController(
             rootView: AnyView(
                 ScreenOverlayView()
@@ -53,18 +53,17 @@ final class OverlayWindowManager: ObservableObject {
         )
         overlayHostingController = controller
         let window = NSWindow()
-        window.contentView = NSView()
-        if let contentView = window.contentView {
-            let hostingView = controller.view
-            hostingView.translatesAutoresizingMaskIntoConstraints = false
-            contentView.addSubview(hostingView)
-            NSLayoutConstraint.activate([
-                hostingView.topAnchor.constraint(equalTo: contentView.topAnchor),
-                hostingView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-                hostingView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                hostingView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
-            ])
-        }
+        let contentView = MenuBarPassthroughView()
+        window.contentView = contentView
+        let hostingView = controller.view
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            hostingView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        ])
         configureOverlayWindow(window)
         window.orderFrontRegardless()
         overlayWindow = window
@@ -99,7 +98,7 @@ final class OverlayWindowManager: ObservableObject {
     /// Applies identifier and screen configuration to the overlay window.
     private func configureOverlayWindow(_ window: NSWindow) {
         window.identifier = NSUserInterfaceItemIdentifier("overlay")
-        window.level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue - 1)
+        window.level = .statusBar
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         if let screenFrame = NSScreen.main?.frame {
             window.setFrame(screenFrame, display: true)


### PR DESCRIPTION
## Summary
- Pin `ScreenOverlayView` to the overlay window using Auto Layout to prevent ambiguous NSView warnings and restore menu bar interaction
- Defer menu bar reload until after the menu dismisses to avoid NSMenu runtime assertion

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ea9e99bc8321ac4633aac5c4d995