### PR TITLE
Remove menu bar and show overlay from launch

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -88,6 +88,12 @@ struct InteractiveClassroomApp: App {
                 .environmentObject(interactionService)
         }
         .modelContainer(container)
+
+        WindowGroup(id: "pairingCodes") {
+            PairingCodesView()
+                .environmentObject(pairingService)
+        }
+        .modelContainer(container)
 #else
         WindowGroup {
             ContentView()

--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 import SwiftData
+#if os(macOS)
+import AppKit
+#endif
 
 @main
 struct InteractiveClassroomApp: App {
@@ -53,19 +56,16 @@ struct InteractiveClassroomApp: App {
                 interactionService: interaction
             )
         )
+#if os(macOS)
+        DispatchQueue.main.async {
+            NSApp.sendAction(#selector(NSApplication.openWindow(_:)), to: nil, from: "courseSelection" as NSString)
+        }
+#endif
     }
 
     var body: some Scene {
         let _ = overlayManager
 #if os(macOS)
-        Settings {
-            SettingsView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-        }
-        .modelContainer(container)
-
         WindowGroup(id: "courseSelection") {
             CourseSelectionView()
                 .environmentObject(courseSessionService)
@@ -92,6 +92,14 @@ struct InteractiveClassroomApp: App {
         WindowGroup(id: "pairingCodes") {
             PairingCodesView()
                 .environmentObject(pairingService)
+        }
+        .modelContainer(container)
+
+        Settings {
+            SettingsView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
         }
         .modelContainer(container)
 #else

--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -58,7 +58,7 @@ struct InteractiveClassroomApp: App {
         )
 #if os(macOS)
         DispatchQueue.main.async {
-            NSApp.sendAction(#selector(NSApplication.openWindow(_:)), to: nil, from: "courseSelection" as NSString)
+            NSApp.sendAction(Selector(("openWindow:")), to: nil, from: "courseSelection" as NSString)
         }
 #endif
     }

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -17,6 +17,9 @@ struct ScreenOverlayView: View {
             window.makeKeyAndOrderFront(nil)
         } else {
             NSApp.sendAction(Selector(("openWindow:")), to: nil, from: id as NSString)
+            if let newWindow = NSApp.windows.first(where: { $0.identifier?.rawValue == id }) {
+                newWindow.makeKeyAndOrderFront(nil)
+            }
         }
     }
 

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -12,9 +12,6 @@ struct ScreenOverlayView: View {
     @EnvironmentObject private var interactionService: InteractionService
     @Environment(\.openWindow) private var openWindow
     @State private var isToolbarFolded = false
-    #if os(macOS)
-    @EnvironmentObject private var overlayManager: OverlayWindowManager
-    #endif
 
     #if os(macOS)
     /// Opens or brings to front the window identified by `id`.
@@ -33,9 +30,6 @@ struct ScreenOverlayView: View {
     #endif
 
     private func endCurrentClass() {
-        #if os(macOS)
-        overlayManager.closeOverlay()
-        #endif
         courseSessionService.endClass()
     }
 

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -12,10 +12,11 @@ struct ScreenOverlayView: View {
 
     /// Opens or brings to front the window identified by `id`.
     private func openWindowIfNeeded(id: String) {
+        NSApp.activate(ignoringOtherApps: true)
         if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == id }) {
             window.makeKeyAndOrderFront(nil)
         } else {
-            NSApp.sendAction(Selector(("openWindow:")), to: nil, from: id)
+            NSApp.sendAction(#selector(NSApplication.openWindow(_:)), to: nil, from: id as NSString)
         }
     }
 

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -99,6 +99,19 @@ struct ScreenOverlayView: View {
                             classControlButton
 
                             Button {
+                                openWindowIfNeeded(id: "pairingCodes")
+                            } label: {
+                                Image(systemName: "qrcode")
+                                    .frame(width: 24, height: 24)
+                                    .padding(10)
+                                    .background(.ultraThinMaterial)
+                                    .clipShape(Circle())
+                                    .accessibilityLabel("Pairing Codes")
+                            }
+                            .buttonStyle(.plain)
+                            .frame(width: 44, height: 44)
+
+                            Button {
                                 openWindowIfNeeded(id: "clients")
                             } label: {
                                 Image(systemName: "person.2")

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -1,33 +1,23 @@
-#if os(macOS) || os(iOS)
-import SwiftUI
 #if os(macOS)
+import SwiftUI
 import AppKit
 import CoreGraphics
-#endif
 
 /// Full-screen overlay container responsible for presenting interactive content.
 struct ScreenOverlayView: View {
     @EnvironmentObject private var courseSessionService: CourseSessionService
     @EnvironmentObject private var interactionService: InteractionService
     @EnvironmentObject private var pairingService: PairingService
-    @Environment(\.openWindow) private var openWindow
     @State private var isToolbarFolded = false
 
-    #if os(macOS)
     /// Opens or brings to front the window identified by `id`.
     private func openWindowIfNeeded(id: String) {
         if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == id }) {
             window.makeKeyAndOrderFront(nil)
         } else {
-            openWindow(id: id)
+            NSApp.sendAction(Selector(("openWindow:")), to: nil, from: id)
         }
     }
-    #else
-    /// Opens a new window scene for the given identifier.
-    private func openWindowIfNeeded(id: String) {
-        openWindow(id: id)
-    }
-    #endif
 
     private func endCurrentClass() {
         courseSessionService.endClass()

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -7,9 +7,9 @@ import CoreGraphics
 
 /// Full-screen overlay container responsible for presenting interactive content.
 struct ScreenOverlayView: View {
-    @EnvironmentObject private var pairingService: PairingService
     @EnvironmentObject private var courseSessionService: CourseSessionService
     @EnvironmentObject private var interactionService: InteractionService
+    @EnvironmentObject private var pairingService: PairingService
     @Environment(\.openWindow) private var openWindow
     @State private var isToolbarFolded = false
 
@@ -31,6 +31,41 @@ struct ScreenOverlayView: View {
 
     private func endCurrentClass() {
         courseSessionService.endClass()
+    }
+
+    private func openClassroom() {
+        openWindowIfNeeded(id: "courseSelection")
+    }
+
+    @ViewBuilder
+    private var classControlButton: some View {
+        if pairingService.teacherCode == nil {
+            Button {
+                openClassroom()
+            } label: {
+                Image(systemName: "rectangle.badge.plus")
+                    .frame(width: 24, height: 24)
+                    .padding(10)
+                    .background(.ultraThinMaterial)
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .frame(width: 44, height: 44)
+            .accessibilityLabel("Open Classroom")
+        } else {
+            Button {
+                endCurrentClass()
+            } label: {
+                Image(systemName: "xmark.circle")
+                    .frame(width: 24, height: 24)
+                    .padding(10)
+                    .background(.ultraThinMaterial)
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .frame(width: 44, height: 44)
+            .accessibilityLabel("End Class")
+        }
     }
 
     var body: some View {
@@ -61,20 +96,7 @@ struct ScreenOverlayView: View {
                     Spacer()
                     HStack(spacing: 12) {
                         HStack(spacing: 12) {
-                            if pairingService.teacherCode != nil {
-                                Button {
-                                    endCurrentClass()
-                                } label: {
-                                    Image(systemName: "xmark.circle")
-                                        .frame(width: 24, height: 24)
-                                        .padding(10)
-                                        .background(.ultraThinMaterial)
-                                        .clipShape(Circle())
-                                        .accessibilityLabel("End Class")
-                                }
-                                .buttonStyle(.plain)
-                                .frame(width: 44, height: 44)
-                            }
+                            classControlButton
 
                             Button {
                                 openWindowIfNeeded(id: "clients")

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -16,7 +16,7 @@ struct ScreenOverlayView: View {
         if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == id }) {
             window.makeKeyAndOrderFront(nil)
         } else {
-            NSApp.sendAction(#selector(NSApplication.openWindow(_:)), to: nil, from: id as NSString)
+            NSApp.sendAction(Selector(("openWindow:")), to: nil, from: id as NSString)
         }
     }
 

--- a/InteractiveClassroom/View/Server/PairingCodesView.swift
+++ b/InteractiveClassroom/View/Server/PairingCodesView.swift
@@ -1,0 +1,47 @@
+#if os(macOS)
+import SwiftUI
+
+struct PairingCodesView: View {
+    @EnvironmentObject private var pairingService: PairingService
+    @StateObject private var viewModel = PairingCodesViewModel()
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let teacher = viewModel.teacherCode,
+               let student = viewModel.studentCode {
+                codeBlock(title: "Teacher Code", code: teacher)
+                codeBlock(title: "Student Code", code: student)
+            } else {
+                Text("Classroom not opened")
+                    .font(.headline)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 240)
+        .onAppear {
+            viewModel.bind(to: pairingService)
+        }
+    }
+
+    @ViewBuilder
+    private func codeBlock(title: String, code: String) -> some View {
+        VStack(spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(code)
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+#Preview {
+    let pairing = PairingService()
+    pairing.teacherCode = "123456"
+    pairing.studentCode = "654321"
+    return PairingCodesView()
+        .environmentObject(pairing)
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 import SwiftUI
 import AppKit
+import Foundation
 
 /// Handles presentation of the full-screen overlay window.
 @MainActor
@@ -19,7 +20,9 @@ final class OverlayWindowManager: ObservableObject {
         self.pairingService = pairingService
         self.courseSessionService = courseSessionService
         self.interactionService = interactionService
-        openOverlay()
+        DispatchQueue.main.async { [weak self] in
+            self?.openOverlay()
+        }
     }
 
     /// Presents the overlay configured for full-screen display.

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -1,7 +1,6 @@
 #if os(macOS)
 import SwiftUI
 import AppKit
-import Combine
 
 /// Handles presentation of the full-screen overlay window.
 @MainActor
@@ -12,8 +11,6 @@ final class OverlayWindowManager: ObservableObject {
 
     private var overlayWindow: NSWindow?
     private var originalPresentationOptions: NSApplication.PresentationOptions = []
-    private var cancellables: Set<AnyCancellable> = []
-
     init(
         pairingService: PairingService,
         courseSessionService: CourseSessionService,
@@ -22,18 +19,7 @@ final class OverlayWindowManager: ObservableObject {
         self.pairingService = pairingService
         self.courseSessionService = courseSessionService
         self.interactionService = interactionService
-
-        pairingService.$teacherCode
-            .receive(on: RunLoop.main)
-            .sink { [weak self] code in
-                guard let self else { return }
-                if code != nil {
-                    self.openOverlay()
-                } else {
-                    self.closeOverlay()
-                }
-            }
-            .store(in: &cancellables)
+        openOverlay()
     }
 
     /// Presents the overlay configured for full-screen display.
@@ -46,7 +32,6 @@ final class OverlayWindowManager: ObservableObject {
                 .environmentObject(pairingService)
                 .environmentObject(courseSessionService)
                 .environmentObject(interactionService)
-                .environmentObject(self)
         )
         let window = NSWindow(contentViewController: controller)
         configureOverlayWindow(window)

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -70,7 +70,7 @@ final class OverlayWindowManager: ObservableObject {
     /// Applies identifier and screen configuration to the overlay window.
     private func configureOverlayWindow(_ window: NSWindow) {
         window.identifier = NSUserInterfaceItemIdentifier("overlay")
-        window.level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue - 1)
+        window.level = .normal
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         if let screenFrame = NSScreen.main?.frame {
             window.setFrame(screenFrame, display: true)

--- a/InteractiveClassroom/ViewModel/Server/PairingCodesViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/PairingCodesViewModel.swift
@@ -1,0 +1,26 @@
+import Combine
+import Foundation
+
+@MainActor
+final class PairingCodesViewModel: ObservableObject {
+    @Published var teacherCode: String?
+    @Published var studentCode: String?
+
+    private var cancellables = Set<AnyCancellable>()
+    private var pairingService: PairingService?
+
+    func bind(to service: PairingService) {
+        guard pairingService == nil else { return }
+        pairingService = service
+
+        service.$teacherCode
+            .receive(on: RunLoop.main)
+            .assign(to: \.teacherCode, on: self)
+            .store(in: &cancellables)
+
+        service.$studentCode
+            .receive(on: RunLoop.main)
+            .assign(to: \.studentCode, on: self)
+            .store(in: &cancellables)
+    }
+}


### PR DESCRIPTION
## Summary
- Remove menu bar scene and instantiate overlay at app launch
- Always keep overlay toolbar visible and end class without closing overlay
- Simplify overlay window manager to open on start

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f21aba048321ba9b080579ee06d4