### PR TITLE
fix(server): keep overlay toolbar visible over content

### DIFF
--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -29,6 +29,7 @@ struct MenuBarView: View {
                     overlayManager.closeOverlay()
                     courseSessionService.endClass()
                     viewModel.reloadMenuBar()
+                    viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
                 }
             }
             Button("Clients") {

--- a/InteractiveClassroom/View/Server/Overlay/PassthroughBlurView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/PassthroughBlurView.swift
@@ -1,0 +1,32 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+/// NSVisualEffectView that ignores all mouse events, allowing clicks to pass through.
+final class PassthroughVisualEffectView: NSVisualEffectView {
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+}
+
+/// A blurred background view that forwards mouse events to views underneath.
+struct PassthroughBlurView: NSViewRepresentable {
+    var tint: Color
+
+    func makeNSView(context: Context) -> PassthroughVisualEffectView {
+        let view = PassthroughVisualEffectView()
+        view.state = .active
+        view.material = .hudWindow
+        view.blendingMode = .behindWindow
+        view.wantsLayer = true
+        updateTint(for: view)
+        return view
+    }
+
+    func updateNSView(_ nsView: PassthroughVisualEffectView, context: Context) {
+        updateTint(for: nsView)
+    }
+
+    private func updateTint(for view: NSVisualEffectView) {
+        view.layer?.backgroundColor = NSColor(tint).withAlphaComponent(0.4).cgColor
+    }
+}
+#endif

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -35,8 +35,11 @@ struct ScreenOverlayView: View {
     private func endCurrentClass() {
         #if os(macOS)
         overlayManager.closeOverlay()
-        #endif
         courseSessionService.endClass()
+        openWindowIfNeeded(id: "courseSelection")
+        #else
+        courseSessionService.endClass()
+        #endif
     }
 
     var body: some View {

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -63,6 +63,7 @@ struct ScreenOverlayView: View {
                         }
                     }
                 }
+                .allowsHitTesting(interactionService.isOverlayContentVisible)
             }
             VStack {
                 Spacer()
@@ -193,7 +194,9 @@ struct ScreenOverlayView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .ignoresSafeArea()
             .zIndex(1) // Ensure toolbar remains above overlay content
+            .allowsHitTesting(true)
         }
+        .allowsHitTesting(false)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.clear)
         .ignoresSafeArea(.all)

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -189,6 +189,7 @@ struct ScreenOverlayView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .ignoresSafeArea()
+            .zIndex(1) // Ensure toolbar remains above overlay content
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.clear)
@@ -206,11 +207,19 @@ struct FullScreenOverlay<Content: View>: View {
     var body: some View {
         ZStack {
             if isVisible {
+#if os(macOS)
+                PassthroughBlurView(tint: background)
+                    .ignoresSafeArea()
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
+#else
                 Rectangle()
                     .fill(background.opacity(0.4))
                     .background(.ultraThinMaterial)
                     .ignoresSafeArea()
+                    .allowsHitTesting(false)
                     .transition(.opacity)
+#endif
             }
 
             if isVisible {


### PR DESCRIPTION
## Summary
- Allow overlay blur background to pass mouse events on macOS
- Keep overlay toolbar visible above overlay content
- Prevent EXC_BAD_ACCESS by replacing blurred background with mouse-passthrough view on macOS
- Expose blur passthrough view type so representable methods compile
- Apply opacity transition modifiers inside each platform branch to avoid compile errors

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fdf8c63483219e39a203803205c4