### PR TITLE
Stabilize server menu bar entries with disabled placeholders

### DIFF
--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -19,16 +19,17 @@ struct MenuBarView: View {
                 .disabled(pairingService.studentCode == nil)
             Text(pairingService.connectionStatus)
             Divider()
-            Button("Open Classroom") {
-                viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+            Button(
+                pairingService.teacherCode == nil ? "Open Classroom" : "End Class"
+            ) {
+                if pairingService.teacherCode == nil {
+                    viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+                } else {
+                    overlayManager.closeOverlay()
+                    courseSessionService.endClass()
+                    viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+                }
             }
-            .disabled(pairingService.teacherCode != nil)
-            Button("End Class") {
-                overlayManager.closeOverlay()
-                courseSessionService.endClass()
-                viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
-            }
-            .disabled(pairingService.teacherCode == nil)
             Button("Clients") {
                 viewModel.openWindowIfNeeded(id: "clients", openWindow: openWindow)
             }

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -22,19 +22,25 @@ struct MenuBarView: View {
             Button(
                 pairingService.teacherCode == nil ? "Open Classroom" : "End Class"
             ) {
-                if pairingService.teacherCode == nil {
-                    viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
-                } else {
-                    overlayManager.closeOverlay()
-                    courseSessionService.endClass()
-                    viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+                viewModel.runAfterMenuDismissal {
+                    if pairingService.teacherCode == nil {
+                        viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+                    } else {
+                        overlayManager.closeOverlay()
+                        courseSessionService.endClass()
+                        viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+                    }
                 }
             }
             Button("Clients") {
-                viewModel.openWindowIfNeeded(id: "clients", openWindow: openWindow)
+                viewModel.runAfterMenuDismissal {
+                    viewModel.openWindowIfNeeded(id: "clients", openWindow: openWindow)
+                }
             }
             Button("Courses") {
-                viewModel.openWindowIfNeeded(id: "courseManager", openWindow: openWindow)
+                viewModel.runAfterMenuDismissal {
+                    viewModel.openWindowIfNeeded(id: "courseManager", openWindow: openWindow)
+                }
             }
             if #available(macOS 13, *) {
                 SettingsLink {
@@ -42,12 +48,16 @@ struct MenuBarView: View {
                 }
             } else {
                 Button("Settings") {
-                    NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+                    viewModel.runAfterMenuDismissal {
+                        NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+                    }
                 }
             }
             Divider()
             Button("Quit") {
-                NSApp.terminate(nil)
+                viewModel.runAfterMenuDismissal {
+                    NSApp.terminate(nil)
+                }
             }
         }
     }

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -23,13 +23,12 @@ struct MenuBarView: View {
                 pairingService.teacherCode == nil ? "Open Classroom" : "End Class"
             ) {
                 viewModel.runAfterMenuDismissal {
-                    if pairingService.teacherCode == nil {
-                        viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
-                    } else {
-                        overlayManager.closeOverlay()
-                        courseSessionService.endClass()
-                        viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
-                    }
+                    viewModel.handleClassAction(
+                        pairingService: pairingService,
+                        overlayManager: overlayManager,
+                        courseSessionService: courseSessionService,
+                        openWindow: openWindow
+                    )
                 }
             }
             Button("Clients") {

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -13,21 +13,22 @@ struct MenuBarView: View {
 
     var body: some View {
         Group {
-            Text("Teacher Key: \(pairingService.teacherCode ?? "")")
-                .opacity(pairingService.teacherCode == nil ? 0 : 1)
-            Text("Student Key: \(pairingService.studentCode ?? "")")
-                .opacity(pairingService.studentCode == nil ? 0 : 1)
+            Text("Teacher Key: \(pairingService.teacherCode ?? "—")")
+                .disabled(pairingService.teacherCode == nil)
+            Text("Student Key: \(pairingService.studentCode ?? "—")")
+                .disabled(pairingService.studentCode == nil)
             Text(pairingService.connectionStatus)
             Divider()
-            Button(pairingService.teacherCode == nil ? "Open Classroom" : "End Class") {
-                if pairingService.teacherCode == nil {
-                    viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
-                } else {
-                    overlayManager.closeOverlay()
-                    courseSessionService.endClass()
-                    viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
-                }
+            Button("Open Classroom") {
+                viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
             }
+            .disabled(pairingService.teacherCode != nil)
+            Button("End Class") {
+                overlayManager.closeOverlay()
+                courseSessionService.endClass()
+                viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+            }
+            .disabled(pairingService.teacherCode == nil)
             Button("Clients") {
                 viewModel.openWindowIfNeeded(id: "clients", openWindow: openWindow)
             }

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -23,5 +23,26 @@ final class MenuBarViewModel: ObservableObject {
             openWindow(id: id)
         }
     }
+
+    /// Handles the primary classroom action based on pairing state.
+    /// - Parameters:
+    ///   - pairingService: Current pairing service to inspect for active session.
+    ///   - overlayManager: Overlay manager used when ending a class.
+    ///   - courseSessionService: Session service controlling class lifecycle.
+    ///   - openWindow: Action to present the course selection window.
+    func handleClassAction(
+        pairingService: PairingService,
+        overlayManager: OverlayWindowManager,
+        courseSessionService: CourseSessionService,
+        openWindow: OpenWindowAction
+    ) {
+        if pairingService.teacherCode == nil {
+            openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+        } else {
+            overlayManager.closeOverlay()
+            courseSessionService.endClass()
+            openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+        }
+    }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -10,7 +10,9 @@ final class MenuBarViewModel: ObservableObject {
     /// windows or changing application state.
     func runAfterMenuDismissal(_ action: @escaping () -> Void) {
         DispatchQueue.main.async {
-            action()
+            DispatchQueue.main.async {
+                action()
+            }
         }
     }
 

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -5,6 +5,15 @@ import AppKit
 /// Handles macOS menu bar window interactions.
 @MainActor
 final class MenuBarViewModel: ObservableObject {
+    /// Schedules `action` to run after the current menu tracking cycle ends.
+    /// This avoids interfering with the menu's internal event loop when opening
+    /// windows or changing application state.
+    func runAfterMenuDismissal(_ action: @escaping () -> Void) {
+        DispatchQueue.main.async {
+            action()
+        }
+    }
+
     /// Opens a window identified by `id` if one isn't already visible.
     /// If the window exists, it is brought to the front instead of creating a duplicate.
     func openWindowIfNeeded(id: String, openWindow: OpenWindowAction) {


### PR DESCRIPTION
## Summary
- Show teacher and student key slots consistently and disable them when codes are missing
- Replace swapping "Open Classroom"/"End Class" with two persistent actions and disable the inactive one
- Rely on SwiftUI state updates to keep the menu bar stable without manual refreshes

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -list -project InteractiveClassroom.xcodeproj` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a3403b69b08321b9e14ff9cc88b165