### PR TITLE
Ensure overlay closes and rebuild menu bar

### DIFF
--- a/InteractiveClassroom/View/Server/MenuBarDebugView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarDebugView.swift
@@ -1,0 +1,25 @@
+#if os(macOS)
+import SwiftUI
+
+/// Debug view providing manual controls for menu bar rebuilding.
+struct MenuBarDebugView: View {
+    @StateObject private var viewModel: MenuBarDebugViewModel
+
+    init(coordinator: MenuBarCoordinator) {
+        _viewModel = StateObject(wrappedValue: MenuBarDebugViewModel(coordinator: coordinator))
+    }
+
+    var body: some View {
+        VStack {
+            Button("Rebuild Menu Bar") {
+                viewModel.rebuildMenuBar()
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    MenuBarDebugView(coordinator: MenuBarCoordinator())
+}
+#endif

--- a/InteractiveClassroom/View/Server/MenuBarDebugView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarDebugView.swift
@@ -1,4 +1,4 @@
-#if os(macOS)
+#if os(macOS) && DEBUG
 import SwiftUI
 
 /// Debug view providing manual controls for menu bar rebuilding.

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -31,18 +31,20 @@ struct MenuBarScene: Scene {
         )
     }
 
+    @SceneBuilder
     var body: some Scene {
-        MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
-            MenuBarView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-                .environmentObject(overlayManager)
-                .environmentObject(menuBarCoordinator)
+        if menuBarCoordinator.isPresented {
+            MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
+                MenuBarView()
+                    .environmentObject(pairingService)
+                    .environmentObject(courseSessionService)
+                    .environmentObject(interactionService)
+                    .environmentObject(overlayManager)
+                    .environmentObject(menuBarCoordinator)
+            }
+            .menuBarExtraStyle(.menu)
+            .modelContainer(container)
         }
-        .id(menuBarCoordinator.refreshID)
-        .menuBarExtraStyle(.menu)
-        .modelContainer(container)
         Settings {
             SettingsView()
                 .environmentObject(pairingService)

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -9,6 +9,7 @@ struct MenuBarScene: Scene {
     @ObservedObject var interactionService: InteractionService
     let container: ModelContainer
     @StateObject private var overlayManager: OverlayWindowManager
+    @StateObject private var menuBarCoordinator = MenuBarCoordinator()
 
     init(
         pairingService: PairingService,
@@ -24,7 +25,8 @@ struct MenuBarScene: Scene {
             wrappedValue: OverlayWindowManager(
                 pairingService: pairingService,
                 courseSessionService: courseSessionService,
-                interactionService: interactionService
+                interactionService: interactionService,
+                menuBarCoordinator: menuBarCoordinator
             )
         )
     }
@@ -36,7 +38,9 @@ struct MenuBarScene: Scene {
                 .environmentObject(courseSessionService)
                 .environmentObject(interactionService)
                 .environmentObject(overlayManager)
+                .environmentObject(menuBarCoordinator)
         }
+        .id(menuBarCoordinator.refreshID)
         .menuBarExtraStyle(.menu)
         .modelContainer(container)
         Settings {

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -9,7 +9,7 @@ struct MenuBarScene: Scene {
     @ObservedObject var interactionService: InteractionService
     let container: ModelContainer
     @StateObject private var overlayManager: OverlayWindowManager
-    @StateObject private var menuBarCoordinator = MenuBarCoordinator()
+    @StateObject private var menuBarCoordinator: MenuBarCoordinator
 
     init(
         pairingService: PairingService,
@@ -21,12 +21,15 @@ struct MenuBarScene: Scene {
         self.courseSessionService = courseSessionService
         self.interactionService = interactionService
         self.container = container
+
+        let coordinator = MenuBarCoordinator()
+        _menuBarCoordinator = StateObject(wrappedValue: coordinator)
         _overlayManager = StateObject(
             wrappedValue: OverlayWindowManager(
                 pairingService: pairingService,
                 courseSessionService: courseSessionService,
                 interactionService: interactionService,
-                menuBarCoordinator: menuBarCoordinator
+                menuBarCoordinator: coordinator
             )
         )
     }

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -14,6 +14,7 @@ struct ScreenOverlayView: View {
     @State private var isToolbarFolded = false
     #if os(macOS)
     @EnvironmentObject private var overlayManager: OverlayWindowManager
+    @EnvironmentObject private var menuBarCoordinator: MenuBarCoordinator
     #endif
 
     #if os(macOS)
@@ -36,6 +37,10 @@ struct ScreenOverlayView: View {
         #if os(macOS)
         overlayManager.closeOverlay()
         courseSessionService.endClass()
+        overlayManager.closeOverlay()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            menuBarCoordinator.rebuildMenuBar()
+        }
         openWindowIfNeeded(id: "courseSelection")
         #else
         courseSessionService.endClass()

--- a/InteractiveClassroom/ViewModel/Server/MenuBarCoordinator.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarCoordinator.swift
@@ -4,12 +4,15 @@ import SwiftUI
 /// Coordinates rebuilding of the Menu Bar Extra.
 @MainActor
 final class MenuBarCoordinator: ObservableObject {
-    /// Identifier used to force SwiftUI to recreate the menu bar extra.
-    @Published private(set) var refreshID = UUID()
+    /// Controls whether the menu bar extra is currently displayed.
+    @Published private(set) var isPresented = true
 
     /// Removes and recreates the menu bar extra.
     func rebuildMenuBar() {
-        refreshID = UUID()
+        isPresented = false
+        DispatchQueue.main.async { [weak self] in
+            self?.isPresented = true
+        }
     }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarCoordinator.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarCoordinator.swift
@@ -1,0 +1,15 @@
+#if os(macOS)
+import SwiftUI
+
+/// Coordinates rebuilding of the Menu Bar Extra.
+@MainActor
+final class MenuBarCoordinator: ObservableObject {
+    /// Identifier used to force SwiftUI to recreate the menu bar extra.
+    @Published private(set) var refreshID = UUID()
+
+    /// Removes and recreates the menu bar extra.
+    func rebuildMenuBar() {
+        refreshID = UUID()
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
@@ -1,0 +1,18 @@
+#if os(macOS)
+import SwiftUI
+
+/// View model powering the debug interface for menu bar operations.
+@MainActor
+final class MenuBarDebugViewModel: ObservableObject {
+    private let coordinator: MenuBarCoordinator
+
+    init(coordinator: MenuBarCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    /// Rebuilds the menu bar extra.
+    func rebuildMenuBar() {
+        coordinator.rebuildMenuBar()
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
@@ -1,4 +1,4 @@
-#if os(macOS)
+#if os(macOS) && DEBUG
 import SwiftUI
 
 /// View model powering the debug interface for menu bar operations.

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -9,6 +9,7 @@ final class OverlayWindowManager: ObservableObject {
     private let pairingService: PairingService
     private let courseSessionService: CourseSessionService
     private let interactionService: InteractionService
+    private let menuBarCoordinator: MenuBarCoordinator
 
     private var overlayWindow: NSWindow?
     private var originalPresentationOptions: NSApplication.PresentationOptions = []
@@ -20,11 +21,13 @@ final class OverlayWindowManager: ObservableObject {
     init(
         pairingService: PairingService,
         courseSessionService: CourseSessionService,
-        interactionService: InteractionService
+        interactionService: InteractionService,
+        menuBarCoordinator: MenuBarCoordinator
     ) {
         self.pairingService = pairingService
         self.courseSessionService = courseSessionService
         self.interactionService = interactionService
+        self.menuBarCoordinator = menuBarCoordinator
 
         pairingService.$teacherCode
             .receive(on: RunLoop.main)
@@ -64,6 +67,7 @@ final class OverlayWindowManager: ObservableObject {
                     .environmentObject(self.courseSessionService)
                     .environmentObject(self.interactionService)
                     .environmentObject(self)
+                    .environmentObject(self.menuBarCoordinator)
             )
             let window = NSWindow(contentViewController: controller)
             self.configureOverlayWindow(window)

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -124,9 +124,7 @@ final class OverlayWindowManager: ObservableObject {
         window.isReleasedWhenClosed = false
     }
     
-    /// Executes work after any active NSMenu tracking has ended, then waits one frame.
-    /// Executes work after any active NSMenu tracking has ended, then waits one frame.
-    /// Executes work after any active NSMenu tracking has ended, then waits one frame.
+    /// Executes work after any active `NSMenu` tracking has ended, then waits one frame.
     private func performAfterMenuClosed(_ work: @MainActor @Sendable @escaping () -> Void) {
         let nc = NotificationCenter.default
         // One-shot using Combine; avoids token capture in @Sendable closures.

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -127,7 +127,7 @@ final class OverlayWindowManager: ObservableObject {
     /// Executes work after any active NSMenu tracking has ended, then waits one frame.
     /// Executes work after any active NSMenu tracking has ended, then waits one frame.
     /// Executes work after any active NSMenu tracking has ended, then waits one frame.
-    private func performAfterMenuClosed(_ work: @escaping () -> Void) {
+    private func performAfterMenuClosed(_ work: @MainActor @Sendable @escaping () -> Void) {
         let nc = NotificationCenter.default
         // One-shot using Combine; avoids token capture in @Sendable closures.
         menuEndTrackingOnce = nc.publisher(for: NSMenu.didEndTrackingNotification)


### PR DESCRIPTION
## Summary
- Ensure overlay closes fully before ending a class
- Rebuild the menu bar extra after class end via new `MenuBarCoordinator`
- Add debug view and view model to manually trigger menu bar rebuilds

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f1c3a29c83219e8fa82e8ced753e