### PR TITLE
Ensure overlay shutdown and rebuild menu bar extra after class ends

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -13,6 +13,7 @@ struct InteractiveClassroomApp: App {
     @StateObject private var pairingService: PairingService
     @StateObject private var courseSessionService: CourseSessionService
     @StateObject private var interactionService: InteractionService
+    @StateObject private var menuBarManager = MenuBarExtraManager()
     private let container: ModelContainer
 
     init() {
@@ -52,8 +53,10 @@ struct InteractiveClassroomApp: App {
             pairingService: pairingService,
             courseSessionService: courseSessionService,
             interactionService: interactionService,
+            menuBarManager: menuBarManager,
             container: container
         )
+        .id(menuBarManager.menuBarExtraID)
 #else
         WindowGroup {
             ContentView()

--- a/InteractiveClassroom/View/Server/MenuBarDebugView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarDebugView.swift
@@ -1,0 +1,24 @@
+#if os(macOS)
+import SwiftUI
+
+/// Simple debug interface providing manual menu bar rebuild.
+struct MenuBarDebugView: View {
+    @EnvironmentObject private var menuBarManager: MenuBarExtraManager
+    @StateObject private var viewModel = MenuBarDebugViewModel()
+
+    var body: some View {
+        VStack {
+            Button("Rebuild Menu Bar") {
+                viewModel.rebuildMenuBar(using: menuBarManager)
+            }
+            .padding()
+        }
+        .frame(minWidth: 200, minHeight: 100)
+    }
+}
+
+#Preview {
+    MenuBarDebugView()
+        .environmentObject(MenuBarExtraManager())
+}
+#endif

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -7,6 +7,7 @@ struct MenuBarScene: Scene {
     @ObservedObject var pairingService: PairingService
     @ObservedObject var courseSessionService: CourseSessionService
     @ObservedObject var interactionService: InteractionService
+    @ObservedObject var menuBarManager: MenuBarExtraManager
     let container: ModelContainer
     @StateObject private var overlayManager: OverlayWindowManager
 
@@ -14,17 +15,20 @@ struct MenuBarScene: Scene {
         pairingService: PairingService,
         courseSessionService: CourseSessionService,
         interactionService: InteractionService,
+        menuBarManager: MenuBarExtraManager,
         container: ModelContainer
     ) {
         self.pairingService = pairingService
         self.courseSessionService = courseSessionService
         self.interactionService = interactionService
+        self.menuBarManager = menuBarManager
         self.container = container
         _overlayManager = StateObject(
             wrappedValue: OverlayWindowManager(
                 pairingService: pairingService,
                 courseSessionService: courseSessionService,
-                interactionService: interactionService
+                interactionService: interactionService,
+                menuBarManager: menuBarManager
             )
         )
     }
@@ -36,6 +40,7 @@ struct MenuBarScene: Scene {
                 .environmentObject(courseSessionService)
                 .environmentObject(interactionService)
                 .environmentObject(overlayManager)
+                .environmentObject(menuBarManager)
         }
         .menuBarExtraStyle(.menu)
         .modelContainer(container)
@@ -66,6 +71,10 @@ struct MenuBarScene: Scene {
                 .environmentObject(interactionService)
         }
         .modelContainer(container)
+        WindowGroup(id: "menuBarDebug") {
+            MenuBarDebugView()
+                .environmentObject(menuBarManager)
+        }
     }
 }
 #endif

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -8,6 +8,7 @@ struct MenuBarView: View {
     @EnvironmentObject private var courseSessionService: CourseSessionService
     @EnvironmentObject private var interactionService: InteractionService
     @EnvironmentObject private var overlayManager: OverlayWindowManager
+    @EnvironmentObject private var menuBarManager: MenuBarExtraManager
     @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = MenuBarViewModel()
 
@@ -32,6 +33,7 @@ struct MenuBarView: View {
                     Task { @MainActor in
                         overlayManager.closeOverlay()
                         courseSessionService.endClass()
+                        menuBarManager.rebuildMenuBarExtra()
                         viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
                     }
                 }
@@ -71,15 +73,18 @@ struct MenuBarView: View {
     let pairing = PairingService()
     let interaction = InteractionService(manager: pairing)
     let courseService = CourseSessionService(manager: pairing, interactionService: interaction)
+    let menuBarManager = MenuBarExtraManager()
     let overlayManager = OverlayWindowManager(
         pairingService: pairing,
         courseSessionService: courseService,
-        interactionService: interaction
+        interactionService: interaction,
+        menuBarManager: menuBarManager
     )
     return MenuBarView()
         .environmentObject(pairing)
         .environmentObject(courseService)
         .environmentObject(interaction)
         .environmentObject(overlayManager)
+        .environmentObject(menuBarManager)
 }
 #endif

--- a/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/ScreenOverlayView.swift
@@ -14,6 +14,7 @@ struct ScreenOverlayView: View {
     @State private var isToolbarFolded = false
     #if os(macOS)
     @EnvironmentObject private var overlayManager: OverlayWindowManager
+    @EnvironmentObject private var menuBarManager: MenuBarExtraManager
     #endif
 
     #if os(macOS)
@@ -36,6 +37,7 @@ struct ScreenOverlayView: View {
         #if os(macOS)
         overlayManager.closeOverlay()
         courseSessionService.endClass()
+        menuBarManager.rebuildMenuBarExtra()
         openWindowIfNeeded(id: "courseSelection")
         #else
         courseSessionService.endClass()

--- a/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
@@ -1,0 +1,10 @@
+#if os(macOS)
+import Foundation
+
+final class MenuBarDebugViewModel: ObservableObject {
+    /// Invokes the rebuild on the provided manager.
+    func rebuildMenuBar(using manager: MenuBarExtraManager) {
+        manager.rebuildMenuBarExtra()
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarExtraManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarExtraManager.swift
@@ -1,0 +1,14 @@
+#if os(macOS)
+import Foundation
+import SwiftUI
+
+@MainActor
+final class MenuBarExtraManager: ObservableObject {
+    @Published private(set) var menuBarExtraID = UUID()
+
+    /// Removes and recreates the menu bar extra by changing its identity.
+    func rebuildMenuBarExtra() {
+        menuBarExtraID = UUID()
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -9,6 +9,7 @@ final class OverlayWindowManager: ObservableObject {
     private let pairingService: PairingService
     private let courseSessionService: CourseSessionService
     private let interactionService: InteractionService
+    private let menuBarManager: MenuBarExtraManager
 
     private var overlayWindow: NSWindow?
     private var originalPresentationOptions: NSApplication.PresentationOptions = []
@@ -20,11 +21,13 @@ final class OverlayWindowManager: ObservableObject {
     init(
         pairingService: PairingService,
         courseSessionService: CourseSessionService,
-        interactionService: InteractionService
+        interactionService: InteractionService,
+        menuBarManager: MenuBarExtraManager
     ) {
         self.pairingService = pairingService
         self.courseSessionService = courseSessionService
         self.interactionService = interactionService
+        self.menuBarManager = menuBarManager
 
         pairingService.$teacherCode
             .receive(on: RunLoop.main)
@@ -64,6 +67,7 @@ final class OverlayWindowManager: ObservableObject {
                     .environmentObject(self.courseSessionService)
                     .environmentObject(self.interactionService)
                     .environmentObject(self)
+                    .environmentObject(self.menuBarManager)
             )
             let window = NSWindow(contentViewController: controller)
             self.configureOverlayWindow(window)


### PR DESCRIPTION
## Summary
- Close the overlay before ending class and trigger a menu bar extra rebuild
- Introduce MenuBarExtraManager with debug view and view model for manual rebuilds
- Inject menu bar manager throughout macOS views for consistent status bar refresh

## Testing
- `swift build` *(fails: Could not find Package.swift)*

## Additional Notes
- Add `MenuBarExtraManager`, `MenuBarDebugViewModel`, and `MenuBarDebugView` to the Xcode project to compile.

------
https://chatgpt.com/codex/tasks/task_e_68a3f1c3a29c83219e8fa82e8ced753e