### PR TITLE
Ensure overlay closes and rebuild menu bar

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -13,6 +13,7 @@ struct InteractiveClassroomApp: App {
     @StateObject private var pairingService: PairingService
     @StateObject private var courseSessionService: CourseSessionService
     @StateObject private var interactionService: InteractionService
+    @StateObject private var menuBarController = MenuBarExtraController()
     private let container: ModelContainer
 
     init() {
@@ -48,12 +49,17 @@ struct InteractiveClassroomApp: App {
 
     var body: some Scene {
 #if os(macOS)
-        MenuBarScene(
-            pairingService: pairingService,
-            courseSessionService: courseSessionService,
-            interactionService: interactionService,
-            container: container
-        )
+        Group {
+            if menuBarController.isVisible {
+                MenuBarScene(
+                    pairingService: pairingService,
+                    courseSessionService: courseSessionService,
+                    interactionService: interactionService,
+                    menuBarController: menuBarController,
+                    container: container
+                )
+            }
+        }
 #else
         WindowGroup {
             ContentView()

--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -49,17 +49,13 @@ struct InteractiveClassroomApp: App {
 
     var body: some Scene {
 #if os(macOS)
-        Group {
-            if menuBarController.isVisible {
-                MenuBarScene(
-                    pairingService: pairingService,
-                    courseSessionService: courseSessionService,
-                    interactionService: interactionService,
-                    menuBarController: menuBarController,
-                    container: container
-                )
-            }
-        }
+        MenuBarScene(
+            pairingService: pairingService,
+            courseSessionService: courseSessionService,
+            interactionService: interactionService,
+            menuBarController: menuBarController,
+            container: container
+        )
 #else
         WindowGroup {
             ContentView()

--- a/InteractiveClassroom/Model/PeerConnection/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnection/PeerConnectionManager.swift
@@ -43,13 +43,17 @@ class PeerConnectionManager: NSObject, ObservableObject {
     @Published var currentCourse: Course? {
         didSet {
             guard oldValue?.persistentModelID != currentCourse?.persistentModelID else { return }
-            interactionHandler?.broadcastCurrentState(to: nil)
+            Task { @MainActor [weak interactionHandler] in
+                interactionHandler?.broadcastCurrentState(to: nil)
+            }
         }
     }
     @Published var currentLesson: Lesson? {
         didSet {
             guard oldValue?.persistentModelID != currentLesson?.persistentModelID else { return }
-            interactionHandler?.broadcastCurrentState(to: nil)
+            Task { @MainActor [weak interactionHandler] in
+                interactionHandler?.broadcastCurrentState(to: nil)
+            }
         }
     }
 

--- a/InteractiveClassroom/View/Server/MenuBarDebugView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarDebugView.swift
@@ -1,0 +1,25 @@
+#if os(macOS)
+import SwiftUI
+
+/// Debugging view with a button to rebuild the menu bar.
+struct MenuBarDebugView: View {
+    @EnvironmentObject private var menuBarController: MenuBarExtraController
+    @StateObject private var viewModel = MenuBarDebugViewModel()
+
+    var body: some View {
+        VStack {
+            Button("Rebuild Menu Bar") {
+                viewModel.rebuildMenuBar(using: menuBarController)
+            }
+            .padding()
+        }
+        .frame(minWidth: 200, minHeight: 80)
+    }
+}
+
+#Preview {
+    let controller = MenuBarExtraController()
+    MenuBarDebugView()
+        .environmentObject(controller)
+}
+#endif

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -7,6 +7,7 @@ struct MenuBarScene: Scene {
     @ObservedObject var pairingService: PairingService
     @ObservedObject var courseSessionService: CourseSessionService
     @ObservedObject var interactionService: InteractionService
+    @ObservedObject var menuBarController: MenuBarExtraController
     let container: ModelContainer
     @StateObject private var overlayManager: OverlayWindowManager
 
@@ -14,11 +15,13 @@ struct MenuBarScene: Scene {
         pairingService: PairingService,
         courseSessionService: CourseSessionService,
         interactionService: InteractionService,
+        menuBarController: MenuBarExtraController,
         container: ModelContainer
     ) {
         self.pairingService = pairingService
         self.courseSessionService = courseSessionService
         self.interactionService = interactionService
+        self.menuBarController = menuBarController
         self.container = container
         _overlayManager = StateObject(
             wrappedValue: OverlayWindowManager(
@@ -30,41 +33,46 @@ struct MenuBarScene: Scene {
     }
 
     var body: some Scene {
-        MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
-            MenuBarView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-                .environmentObject(overlayManager)
+        Group {
+            if menuBarController.isVisible {
+                MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
+                    MenuBarView()
+                        .environmentObject(pairingService)
+                        .environmentObject(courseSessionService)
+                        .environmentObject(interactionService)
+                        .environmentObject(menuBarController)
+                        .environmentObject(overlayManager)
+                }
+                .modelContainer(container)
+            }
+            Settings {
+                SettingsView()
+                    .environmentObject(pairingService)
+                    .environmentObject(courseSessionService)
+                    .environmentObject(interactionService)
+            }
+            .modelContainer(container)
+            WindowGroup(id: "courseSelection") {
+                CourseSelectionView()
+                    .environmentObject(courseSessionService)
+                    .environmentObject(pairingService)
+            }
+            .modelContainer(container)
+            WindowGroup(id: "clients") {
+                ClientsListView()
+                    .environmentObject(pairingService)
+                    .environmentObject(courseSessionService)
+                    .environmentObject(interactionService)
+            }
+            .modelContainer(container)
+            WindowGroup(id: "courseManager") {
+                CourseManagerView()
+                    .environmentObject(pairingService)
+                    .environmentObject(courseSessionService)
+                    .environmentObject(interactionService)
+            }
+            .modelContainer(container)
         }
-        .modelContainer(container)
-        Settings {
-            SettingsView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-        }
-        .modelContainer(container)
-        WindowGroup(id: "courseSelection") {
-            CourseSelectionView()
-                .environmentObject(courseSessionService)
-                .environmentObject(pairingService)
-        }
-        .modelContainer(container)
-        WindowGroup(id: "clients") {
-            ClientsListView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-        }
-        .modelContainer(container)
-        WindowGroup(id: "courseManager") {
-            CourseManagerView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-        }
-        .modelContainer(container)
     }
 }
 #endif

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -33,46 +33,50 @@ struct MenuBarScene: Scene {
     }
 
     var body: some Scene {
-        Group {
-            if menuBarController.isVisible {
-                MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
-                    MenuBarView()
-                        .environmentObject(pairingService)
-                        .environmentObject(courseSessionService)
-                        .environmentObject(interactionService)
-                        .environmentObject(menuBarController)
-                        .environmentObject(overlayManager)
-                }
-                .modelContainer(container)
-            }
-            Settings {
-                SettingsView()
-                    .environmentObject(pairingService)
-                    .environmentObject(courseSessionService)
-                    .environmentObject(interactionService)
-            }
-            .modelContainer(container)
-            WindowGroup(id: "courseSelection") {
-                CourseSelectionView()
-                    .environmentObject(courseSessionService)
-                    .environmentObject(pairingService)
-            }
-            .modelContainer(container)
-            WindowGroup(id: "clients") {
-                ClientsListView()
-                    .environmentObject(pairingService)
-                    .environmentObject(courseSessionService)
-                    .environmentObject(interactionService)
-            }
-            .modelContainer(container)
-            WindowGroup(id: "courseManager") {
-                CourseManagerView()
-                    .environmentObject(pairingService)
-                    .environmentObject(courseSessionService)
-                    .environmentObject(interactionService)
-            }
-            .modelContainer(container)
+        MenuBarExtra(
+            "InteractiveClassroom",
+            systemImage: "graduationcap",
+            isInserted: $menuBarController.isVisible
+        ) {
+            MenuBarView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+                .environmentObject(menuBarController)
+                .environmentObject(overlayManager)
         }
+        .modelContainer(container)
+
+        Settings {
+            SettingsView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+        }
+        .modelContainer(container)
+
+        WindowGroup(id: "courseSelection") {
+            CourseSelectionView()
+                .environmentObject(courseSessionService)
+                .environmentObject(pairingService)
+        }
+        .modelContainer(container)
+
+        WindowGroup(id: "clients") {
+            ClientsListView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+        }
+        .modelContainer(container)
+
+        WindowGroup(id: "courseManager") {
+            CourseManagerView()
+                .environmentObject(pairingService)
+                .environmentObject(courseSessionService)
+                .environmentObject(interactionService)
+        }
+        .modelContainer(container)
     }
 }
 #endif

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -27,7 +27,6 @@ struct MenuBarView: View {
             Button("End Class") {
                 overlayManager.closeOverlay()
                 courseSessionService.endClass()
-                overlayManager.closeOverlay()
                 menuBarController.rebuild()
                 viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
             }

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -8,6 +8,7 @@ struct MenuBarView: View {
     @EnvironmentObject private var courseSessionService: CourseSessionService
     @EnvironmentObject private var interactionService: InteractionService
     @EnvironmentObject private var overlayManager: OverlayWindowManager
+    @EnvironmentObject private var menuBarController: MenuBarExtraController
     @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = MenuBarViewModel()
 
@@ -26,6 +27,8 @@ struct MenuBarView: View {
             Button("End Class") {
                 overlayManager.closeOverlay()
                 courseSessionService.endClass()
+                overlayManager.closeOverlay()
+                menuBarController.rebuild()
                 viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
             }
             .disabled(pairingService.teacherCode == nil)
@@ -60,10 +63,12 @@ struct MenuBarView: View {
         courseSessionService: courseService,
         interactionService: interaction
     )
+    let menuBarController = MenuBarExtraController()
     return MenuBarView()
         .environmentObject(pairing)
         .environmentObject(courseService)
         .environmentObject(interaction)
         .environmentObject(overlayManager)
+        .environmentObject(menuBarController)
 }
 #endif

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -25,10 +25,12 @@ struct MenuBarView: View {
             }
             .disabled(pairingService.teacherCode != nil)
             Button("End Class") {
-                overlayManager.closeOverlay()
-                courseSessionService.endClass()
-                menuBarController.rebuild()
-                viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+                viewModel.endClass(
+                    overlayManager: overlayManager,
+                    courseSessionService: courseSessionService,
+                    menuBarController: menuBarController,
+                    openWindow: openWindow
+                )
             }
             .disabled(pairingService.teacherCode == nil)
             Button("Clients") {

--- a/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
@@ -5,7 +5,7 @@ import Foundation
 @MainActor
 final class MenuBarDebugViewModel: ObservableObject {
     func rebuildMenuBar(using controller: MenuBarExtraController) {
-        controller.rebuild()
+        Task { await controller.rebuild() }
     }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
@@ -1,0 +1,11 @@
+#if os(macOS)
+import Foundation
+
+/// View model for `MenuBarDebugView` providing access to rebuild actions.
+@MainActor
+final class MenuBarDebugViewModel: ObservableObject {
+    func rebuildMenuBar(using controller: MenuBarExtraController) {
+        controller.rebuild()
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
@@ -7,18 +7,12 @@ final class MenuBarExtraController: ObservableObject {
     /// Indicates whether the MenuBarExtra should be displayed.
     @Published var isVisible: Bool = true
 
-    /// Removes and recreates the MenuBarExtra to clear its state.
-    ///
-    /// State mutations are dispatched asynchronously to avoid publishing
-    /// changes during an ongoing view update, which can lead to undefined
-    /// behavior in SwiftUI.
-    func rebuild() {
-        DispatchQueue.main.async { [weak self] in
-            self?.isVisible = false
-            DispatchQueue.main.async { [weak self] in
-                self?.isVisible = true
-            }
-        }
+    /// Removes and recreates the MenuBarExtra on a later run loop to clear its
+    /// state without mutating during an in-progress view update.
+    func rebuild() async {
+        isVisible = false
+        await Task.yield()
+        isVisible = true
     }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
@@ -5,7 +5,7 @@ import SwiftUI
 @MainActor
 final class MenuBarExtraController: ObservableObject {
     /// Indicates whether the MenuBarExtra should be displayed.
-    @Published private(set) var isVisible: Bool = true
+    @Published var isVisible: Bool = true
 
     /// Removes and recreates the MenuBarExtra to clear its state.
     func rebuild() {

--- a/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
@@ -1,0 +1,18 @@
+#if os(macOS)
+import SwiftUI
+
+/// Controls visibility of the macOS MenuBarExtra and supports rebuilding.
+@MainActor
+final class MenuBarExtraController: ObservableObject {
+    /// Indicates whether the MenuBarExtra should be displayed.
+    @Published private(set) var isVisible: Bool = true
+
+    /// Removes and recreates the MenuBarExtra to clear its state.
+    func rebuild() {
+        isVisible = false
+        DispatchQueue.main.async { [weak self] in
+            self?.isVisible = true
+        }
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
@@ -8,10 +8,16 @@ final class MenuBarExtraController: ObservableObject {
     @Published var isVisible: Bool = true
 
     /// Removes and recreates the MenuBarExtra to clear its state.
+    ///
+    /// State mutations are dispatched asynchronously to avoid publishing
+    /// changes during an ongoing view update, which can lead to undefined
+    /// behavior in SwiftUI.
     func rebuild() {
-        isVisible = false
         DispatchQueue.main.async { [weak self] in
-            self?.isVisible = true
+            self?.isVisible = false
+            DispatchQueue.main.async { [weak self] in
+                self?.isVisible = true
+            }
         }
     }
 }

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -22,10 +22,12 @@ final class MenuBarViewModel: ObservableObject {
         menuBarController: MenuBarExtraController,
         openWindow: OpenWindowAction
     ) {
-        overlayManager.closeOverlay()
-        courseSessionService.endClass()
-        Task { await menuBarController.rebuild() }
-        openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+        Task { @MainActor in
+            overlayManager.closeOverlay()
+            courseSessionService.endClass()
+            await menuBarController.rebuild()
+            openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+        }
     }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -24,7 +24,7 @@ final class MenuBarViewModel: ObservableObject {
     ) {
         overlayManager.closeOverlay()
         courseSessionService.endClass()
-        menuBarController.rebuild()
+        Task { await menuBarController.rebuild() }
         openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
     }
 }

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -14,5 +14,18 @@ final class MenuBarViewModel: ObservableObject {
             openWindow(id: id)
         }
     }
+
+    /// Ends the current class, tears down any overlay windows, and rebuilds the menu bar.
+    func endClass(
+        overlayManager: OverlayWindowManager,
+        courseSessionService: CourseSessionService,
+        menuBarController: MenuBarExtraController,
+        openWindow: OpenWindowAction
+    ) {
+        overlayManager.closeOverlay()
+        courseSessionService.endClass()
+        menuBarController.rebuild()
+        openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+    }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -27,10 +27,12 @@ final class OverlayWindowManager: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] code in
                 guard let self else { return }
-                if code != nil {
-                    self.openOverlay()
-                } else {
-                    self.closeOverlay()
+                Task { @MainActor in
+                    if code != nil {
+                        self.openOverlay()
+                    } else {
+                        self.closeOverlay()
+                    }
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## Summary
- Ensure End Class closes the overlay and triggers a menu bar rebuild
- Add MenuBarExtraController to toggle and rebuild MenuBarExtra
- Introduce MenuBarDebugView for manual menu bar rebuild testing

## Testing
- `swift build` *(fails: Could not find Package.swift)*

## Additional Notes
- Please add the new Swift files to the Xcode project.

------
https://chatgpt.com/codex/tasks/task_e_68a3f6c17bd48321be0e3aba1d73b350