### PR TITLE
Ensure overlay closes and rebuild menu bar after class ends

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -13,6 +13,9 @@ struct InteractiveClassroomApp: App {
     @StateObject private var pairingService: PairingService
     @StateObject private var courseSessionService: CourseSessionService
     @StateObject private var interactionService: InteractionService
+    #if os(macOS)
+    @StateObject private var menuBarManager = MenuBarManager()
+    #endif
     private let container: ModelContainer
 
     init() {
@@ -52,6 +55,7 @@ struct InteractiveClassroomApp: App {
             pairingService: pairingService,
             courseSessionService: courseSessionService,
             interactionService: interactionService,
+            menuBarManager: menuBarManager,
             container: container
         )
 #else

--- a/InteractiveClassroom/View/Server/MenuBarDebugView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarDebugView.swift
@@ -1,0 +1,22 @@
+#if os(macOS)
+import SwiftUI
+
+/// Debug view providing a button to rebuild the menu bar extra.
+struct MenuBarDebugView: View {
+    @StateObject private var viewModel: MenuBarDebugViewModel
+
+    init(menuBarManager: MenuBarManager) {
+        _viewModel = StateObject(wrappedValue: MenuBarDebugViewModel(menuBarManager: menuBarManager))
+    }
+
+    var body: some View {
+        VStack {
+            Button("Rebuild Menu Bar") {
+                viewModel.rebuildMenuBar()
+            }
+            .padding()
+        }
+        .frame(minWidth: 200, minHeight: 100)
+    }
+}
+#endif

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -7,6 +7,7 @@ struct MenuBarScene: Scene {
     @ObservedObject var pairingService: PairingService
     @ObservedObject var courseSessionService: CourseSessionService
     @ObservedObject var interactionService: InteractionService
+    @ObservedObject var menuBarManager: MenuBarManager
     let container: ModelContainer
     @StateObject private var overlayManager: OverlayWindowManager
 
@@ -14,11 +15,13 @@ struct MenuBarScene: Scene {
         pairingService: PairingService,
         courseSessionService: CourseSessionService,
         interactionService: InteractionService,
+        menuBarManager: MenuBarManager,
         container: ModelContainer
     ) {
         self.pairingService = pairingService
         self.courseSessionService = courseSessionService
         self.interactionService = interactionService
+        self.menuBarManager = menuBarManager
         self.container = container
         _overlayManager = StateObject(
             wrappedValue: OverlayWindowManager(
@@ -29,15 +32,20 @@ struct MenuBarScene: Scene {
         )
     }
 
+    @SceneBuilder
     var body: some Scene {
-        MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
-            MenuBarView()
-                .environmentObject(pairingService)
-                .environmentObject(courseSessionService)
-                .environmentObject(interactionService)
-                .environmentObject(overlayManager)
+        if let id = menuBarManager.menuBarID {
+            MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
+                MenuBarView()
+                    .environmentObject(pairingService)
+                    .environmentObject(courseSessionService)
+                    .environmentObject(interactionService)
+                    .environmentObject(overlayManager)
+                    .environmentObject(menuBarManager)
+            }
+            .id(id)
+            .modelContainer(container)
         }
-        .modelContainer(container)
         Settings {
             SettingsView()
                 .environmentObject(pairingService)
@@ -65,6 +73,11 @@ struct MenuBarScene: Scene {
                 .environmentObject(interactionService)
         }
         .modelContainer(container)
+        #if DEBUG
+        WindowGroup(id: "menuBarDebug") {
+            MenuBarDebugView(menuBarManager: menuBarManager)
+        }
+        #endif
     }
 }
 #endif

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -8,6 +8,7 @@ struct MenuBarView: View {
     @EnvironmentObject private var courseSessionService: CourseSessionService
     @EnvironmentObject private var interactionService: InteractionService
     @EnvironmentObject private var overlayManager: OverlayWindowManager
+    @EnvironmentObject private var menuBarManager: MenuBarManager
     @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = MenuBarViewModel()
 
@@ -26,6 +27,9 @@ struct MenuBarView: View {
             Button("End Class") {
                 overlayManager.closeOverlay()
                 courseSessionService.endClass()
+                DispatchQueue.main.async {
+                    menuBarManager.rebuildMenuBar()
+                }
                 viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
             }
             .disabled(pairingService.teacherCode == nil)
@@ -60,10 +64,12 @@ struct MenuBarView: View {
         courseSessionService: courseService,
         interactionService: interaction
     )
+    let menuBarManager = MenuBarManager()
     return MenuBarView()
         .environmentObject(pairing)
         .environmentObject(courseService)
         .environmentObject(interaction)
         .environmentObject(overlayManager)
+        .environmentObject(menuBarManager)
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
@@ -1,0 +1,18 @@
+#if os(macOS)
+import Foundation
+
+/// ViewModel for debugging menu bar reconstruction.
+@MainActor
+final class MenuBarDebugViewModel: ObservableObject {
+    private let menuBarManager: MenuBarManager
+
+    init(menuBarManager: MenuBarManager) {
+        self.menuBarManager = menuBarManager
+    }
+
+    /// Triggers a menu bar rebuild via `MenuBarManager`.
+    func rebuildMenuBar() {
+        menuBarManager.rebuildMenuBar()
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarManager.swift
@@ -1,0 +1,18 @@
+#if os(macOS)
+import SwiftUI
+
+/// Manages the lifecycle of the menu bar extra, allowing it to be removed and rebuilt on demand.
+@MainActor
+final class MenuBarManager: ObservableObject {
+    /// Unique identifier used to force `MenuBarExtra` reconstruction.
+    @Published private(set) var menuBarID: UUID? = UUID()
+
+    /// Removes the current menu bar extra and recreates it on the next run loop.
+    func rebuildMenuBar() {
+        menuBarID = nil
+        DispatchQueue.main.async {
+            self.menuBarID = UUID()
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add `MenuBarManager` to rebuild the MenuBarExtra on demand
- Rebuild menu bar after closing overlay when ending class
- Introduce debug view with button to trigger menu bar rebuild

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -list` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a3f6c17bd48321be0e3aba1d73b350