### PR TITLE
Defer state mutations to prevent view update publishing

### DIFF
--- a/InteractiveClassroom/InteractiveClassroomApp.swift
+++ b/InteractiveClassroom/InteractiveClassroomApp.swift
@@ -13,6 +13,7 @@ struct InteractiveClassroomApp: App {
     @StateObject private var pairingService: PairingService
     @StateObject private var courseSessionService: CourseSessionService
     @StateObject private var interactionService: InteractionService
+    @StateObject private var menuBarController = MenuBarExtraController()
     private let container: ModelContainer
 
     init() {
@@ -52,6 +53,7 @@ struct InteractiveClassroomApp: App {
             pairingService: pairingService,
             courseSessionService: courseSessionService,
             interactionService: interactionService,
+            menuBarController: menuBarController,
             container: container
         )
 #else

--- a/InteractiveClassroom/Model/PeerConnection/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnection/PeerConnectionManager.swift
@@ -43,13 +43,17 @@ class PeerConnectionManager: NSObject, ObservableObject {
     @Published var currentCourse: Course? {
         didSet {
             guard oldValue?.persistentModelID != currentCourse?.persistentModelID else { return }
-            interactionHandler?.broadcastCurrentState(to: nil)
+            Task { @MainActor [weak self] in
+                self?.interactionHandler?.broadcastCurrentState(to: nil)
+            }
         }
     }
     @Published var currentLesson: Lesson? {
         didSet {
             guard oldValue?.persistentModelID != currentLesson?.persistentModelID else { return }
-            interactionHandler?.broadcastCurrentState(to: nil)
+            Task { @MainActor [weak self] in
+                self?.interactionHandler?.broadcastCurrentState(to: nil)
+            }
         }
     }
 

--- a/InteractiveClassroom/View/Server/MenuBarDebugView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarDebugView.swift
@@ -1,0 +1,25 @@
+#if os(macOS)
+import SwiftUI
+
+/// Debugging view with a button to rebuild the menu bar.
+struct MenuBarDebugView: View {
+    @EnvironmentObject private var menuBarController: MenuBarExtraController
+    @StateObject private var viewModel = MenuBarDebugViewModel()
+
+    var body: some View {
+        VStack {
+            Button("Rebuild Menu Bar") {
+                viewModel.rebuildMenuBar(using: menuBarController)
+            }
+            .padding()
+        }
+        .frame(minWidth: 200, minHeight: 80)
+    }
+}
+
+#Preview {
+    let controller = MenuBarExtraController()
+    MenuBarDebugView()
+        .environmentObject(controller)
+}
+#endif

--- a/InteractiveClassroom/View/Server/MenuBarScene.swift
+++ b/InteractiveClassroom/View/Server/MenuBarScene.swift
@@ -7,6 +7,7 @@ struct MenuBarScene: Scene {
     @ObservedObject var pairingService: PairingService
     @ObservedObject var courseSessionService: CourseSessionService
     @ObservedObject var interactionService: InteractionService
+    @ObservedObject var menuBarController: MenuBarExtraController
     let container: ModelContainer
     @StateObject private var overlayManager: OverlayWindowManager
 
@@ -14,11 +15,13 @@ struct MenuBarScene: Scene {
         pairingService: PairingService,
         courseSessionService: CourseSessionService,
         interactionService: InteractionService,
+        menuBarController: MenuBarExtraController,
         container: ModelContainer
     ) {
         self.pairingService = pairingService
         self.courseSessionService = courseSessionService
         self.interactionService = interactionService
+        self.menuBarController = menuBarController
         self.container = container
         _overlayManager = StateObject(
             wrappedValue: OverlayWindowManager(
@@ -30,14 +33,20 @@ struct MenuBarScene: Scene {
     }
 
     var body: some Scene {
-        MenuBarExtra("InteractiveClassroom", systemImage: "graduationcap") {
+        MenuBarExtra(
+            "InteractiveClassroom",
+            systemImage: "graduationcap",
+            isInserted: $menuBarController.isVisible
+        ) {
             MenuBarView()
                 .environmentObject(pairingService)
                 .environmentObject(courseSessionService)
                 .environmentObject(interactionService)
+                .environmentObject(menuBarController)
                 .environmentObject(overlayManager)
         }
         .modelContainer(container)
+
         Settings {
             SettingsView()
                 .environmentObject(pairingService)
@@ -45,12 +54,14 @@ struct MenuBarScene: Scene {
                 .environmentObject(interactionService)
         }
         .modelContainer(container)
+
         WindowGroup(id: "courseSelection") {
             CourseSelectionView()
                 .environmentObject(courseSessionService)
                 .environmentObject(pairingService)
         }
         .modelContainer(container)
+
         WindowGroup(id: "clients") {
             ClientsListView()
                 .environmentObject(pairingService)
@@ -58,6 +69,7 @@ struct MenuBarScene: Scene {
                 .environmentObject(interactionService)
         }
         .modelContainer(container)
+
         WindowGroup(id: "courseManager") {
             CourseManagerView()
                 .environmentObject(pairingService)

--- a/InteractiveClassroom/View/Server/MenuBarView.swift
+++ b/InteractiveClassroom/View/Server/MenuBarView.swift
@@ -8,6 +8,7 @@ struct MenuBarView: View {
     @EnvironmentObject private var courseSessionService: CourseSessionService
     @EnvironmentObject private var interactionService: InteractionService
     @EnvironmentObject private var overlayManager: OverlayWindowManager
+    @EnvironmentObject private var menuBarController: MenuBarExtraController
     @Environment(\.openWindow) private var openWindow
     @StateObject private var viewModel = MenuBarViewModel()
 
@@ -24,9 +25,12 @@ struct MenuBarView: View {
             }
             .disabled(pairingService.teacherCode != nil)
             Button("End Class") {
-                overlayManager.closeOverlay()
-                courseSessionService.endClass()
-                viewModel.openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+                viewModel.endClass(
+                    overlayManager: overlayManager,
+                    courseSessionService: courseSessionService,
+                    menuBarController: menuBarController,
+                    openWindow: openWindow
+                )
             }
             .disabled(pairingService.teacherCode == nil)
             Button("Clients") {
@@ -60,10 +64,12 @@ struct MenuBarView: View {
         courseSessionService: courseService,
         interactionService: interaction
     )
+    let menuBarController = MenuBarExtraController()
     return MenuBarView()
         .environmentObject(pairing)
         .environmentObject(courseService)
         .environmentObject(interaction)
         .environmentObject(overlayManager)
+        .environmentObject(menuBarController)
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarDebugViewModel.swift
@@ -1,0 +1,11 @@
+#if os(macOS)
+import Foundation
+
+/// View model for `MenuBarDebugView` providing access to rebuild actions.
+@MainActor
+final class MenuBarDebugViewModel: ObservableObject {
+    func rebuildMenuBar(using controller: MenuBarExtraController) {
+        Task { await controller.rebuild() }
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarExtraController.swift
@@ -1,0 +1,18 @@
+#if os(macOS)
+import SwiftUI
+
+/// Controls visibility of the macOS MenuBarExtra and supports rebuilding.
+@MainActor
+final class MenuBarExtraController: ObservableObject {
+    /// Indicates whether the MenuBarExtra should be displayed.
+    @Published var isVisible: Bool = true
+
+    /// Removes and recreates the MenuBarExtra on a later run loop to clear its
+    /// state without mutating during an in-progress view update.
+    func rebuild() async {
+        isVisible = false
+        await Task.yield()
+        isVisible = true
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MenuBarViewModel.swift
@@ -14,5 +14,20 @@ final class MenuBarViewModel: ObservableObject {
             openWindow(id: id)
         }
     }
+
+    /// Ends the current class, tears down any overlay windows, and rebuilds the menu bar.
+    func endClass(
+        overlayManager: OverlayWindowManager,
+        courseSessionService: CourseSessionService,
+        menuBarController: MenuBarExtraController,
+        openWindow: OpenWindowAction
+    ) {
+        Task { @MainActor in
+            overlayManager.closeOverlay()
+            courseSessionService.endClass()
+            await menuBarController.rebuild()
+            openWindowIfNeeded(id: "courseSelection", openWindow: openWindow)
+        }
+    }
 }
 #endif

--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -27,10 +27,12 @@ final class OverlayWindowManager: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] code in
                 guard let self else { return }
-                if code != nil {
-                    self.openOverlay()
-                } else {
-                    self.closeOverlay()
+                Task { @MainActor in
+                    if code != nil {
+                        self.openOverlay()
+                    } else {
+                        self.closeOverlay()
+                    }
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## Summary
- Dispatch overlay window toggling asynchronously when teacherCode changes
- Break synchronous @Published loops in PeerConnectionManager by dispatching broadcastCurrentState
- Run End Class teardown inside a MainActor Task to avoid menu update conflicts

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f6c17bd48321be0e3aba1d73b350