### PR TITLE
Add multiple choice interaction

### DIFF
--- a/InteractiveClassroom/Model/Interaction/InteractionService.swift
+++ b/InteractiveClassroom/Model/Interaction/InteractionService.swift
@@ -51,8 +51,7 @@ final class InteractionService: ObservableObject {
         let interaction = Interaction(request: request)
         activeInteraction = interaction
 
-        if case .countdown = request.content,
-           let seconds = request.lifecycle.secondsValue {
+        if let seconds = request.lifecycle.secondsValue {
             let service = CountdownService(seconds: seconds)
             countdownService = service
             presentOverlay(request.makeOverlay(countdownService: service))
@@ -61,12 +60,6 @@ final class InteractionService: ObservableObject {
             }
         } else {
             presentOverlay(request.makeOverlay())
-            if case let .finite(seconds) = request.lifecycle {
-                interactionTask = Task { @MainActor [weak self] in
-                    try? await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
-                    self?.endInteraction()
-                }
-            }
         }
 
         if broadcast {

--- a/InteractiveClassroom/Model/Interaction/MultipleChoiceNetworking.swift
+++ b/InteractiveClassroom/Model/Interaction/MultipleChoiceNetworking.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Payload sent from a participant when submitting a multiple-choice answer.
+struct MultipleChoiceAnswerPayload: Codable {
+    /// The display name of the participant.
+    let participant: String
+    /// Identifiers of selected options.
+    let selectedOptionIDs: [String]
+}
+
+/// Aggregated result payload broadcast by the server.
+struct MultipleChoiceResultPayload: Codable {
+    /// Mapping from option identifiers to selection counts.
+    let optionCounts: [String: Int]
+    /// Names of participants who have submitted answers.
+    let submittedNames: [String]
+}

--- a/InteractiveClassroom/Model/Interaction/MultipleChoiceQuestion.swift
+++ b/InteractiveClassroom/Model/Interaction/MultipleChoiceQuestion.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Represents a multiple-choice question configuration.
+struct MultipleChoiceQuestion: Codable, Equatable {
+    /// An individual selectable option.
+    struct Option: Codable, Identifiable, Equatable {
+        /// Unique identifier for the option.
+        var id: String
+        /// Display text for the option.
+        var text: String
+    }
+
+    /// All available options for the question.
+    var options: [Option]
+    /// Identifiers of the correct options.
+    var correctOptionIDs: [String]
+    /// Indicates whether multiple selections are allowed.
+    var allowsMultipleSelection: Bool
+}

--- a/InteractiveClassroom/View/Client/Teacher/MultipleChoiceSetupView.swift
+++ b/InteractiveClassroom/View/Client/Teacher/MultipleChoiceSetupView.swift
@@ -1,0 +1,65 @@
+#if os(iOS)
+import SwiftUI
+
+/// View allowing teachers to configure and launch a multiple-choice interaction.
+struct MultipleChoiceSetupView: View {
+    @EnvironmentObject private var interactionService: InteractionService
+    @StateObject private var viewModel = MultipleChoiceSetupViewModel()
+
+    var body: some View {
+        Form {
+            Section("Duration") {
+                Stepper(value: $viewModel.duration, in: 10...3600, step: 10) {
+                    Text("\(viewModel.duration) s")
+                }
+            }
+
+            Section("Options") {
+                ForEach($viewModel.options) { $option in
+                    HStack {
+                        TextField("Option", text: $option.text)
+                        Button(role: .destructive) {
+                            viewModel.removeOption(id: option.id)
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                Button {
+                    viewModel.addOption()
+                } label: {
+                    Label("Add Option", systemImage: "plus.circle")
+                }
+            }
+
+            Section("Answer") {
+                Toggle("Allow multiple selection", isOn: $viewModel.allowsMultipleSelection)
+                ForEach(viewModel.options) { option in
+                    Button {
+                        viewModel.toggleCorrect(for: option.id)
+                    } label: {
+                        HStack {
+                            Text(option.text.isEmpty ? "Untitled" : option.text)
+                            Spacer()
+                            if viewModel.correctOptionIDs.contains(option.id) {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(.accentColor)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            Section {
+                Button("Start Interaction") {
+                    viewModel.start(interactionService: interactionService)
+                }
+                .disabled(!viewModel.canStart)
+            }
+        }
+        .navigationTitle("Quiz")
+    }
+}
+#endif

--- a/InteractiveClassroom/View/Client/Teacher/TeacherDashboardView.swift
+++ b/InteractiveClassroom/View/Client/Teacher/TeacherDashboardView.swift
@@ -13,7 +13,8 @@ struct TeacherDashboardView: View {
         TabItem(icon: "book.closed.fill", title: "Lessons"),
         TabItem(icon: "gearshape.fill", title: "Settings"),
         TabItem(icon: "chart.bar.xaxis", title: "Reports"),
-        TabItem(icon: "questionmark.circle", title: "Help")
+        TabItem(icon: "questionmark.circle", title: "Help"),
+        TabItem(icon: "list.bullet.rectangle", title: "Quiz")
     ]
 
     var body: some View {
@@ -24,6 +25,7 @@ struct TeacherDashboardView: View {
                 placeholder("Settings").tag(2)
                 placeholder("Reports").tag(3)
                 placeholder("Help").tag(4)
+                MultipleChoiceSetupView().tag(5)
             }
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
 

--- a/InteractiveClassroom/View/Server/Overlay/MultipleChoiceOverlayView.swift
+++ b/InteractiveClassroom/View/Server/Overlay/MultipleChoiceOverlayView.swift
@@ -1,0 +1,30 @@
+#if os(macOS)
+import SwiftUI
+
+/// Overlay presenting multiple-choice statistics and submissions.
+struct MultipleChoiceOverlayView: View {
+    @ObservedObject var viewModel: MultipleChoiceOverlayViewModel
+    @ObservedObject var service: CountdownService
+
+    private func formattedTime(_ seconds: Int) -> String {
+        let minutes = seconds / 60
+        let seconds = seconds % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    var body: some View {
+        ZStack {
+            OverlayTopBarView(
+                questionType: "选择题",
+                remainingTime: formattedTime(service.remainingSeconds)
+            )
+            HStack {
+                OverlayStatsView(stats: viewModel.stats)
+                Spacer()
+                OverlayNamesView(names: viewModel.submittedNames)
+            }
+        }
+        .frame(minWidth: 400, minHeight: 300)
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Client/Teacher/MultipleChoiceSetupViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Client/Teacher/MultipleChoiceSetupViewModel.swift
@@ -1,0 +1,52 @@
+#if os(iOS)
+import Foundation
+
+/// View model managing the creation of a multiple-choice interaction.
+final class MultipleChoiceSetupViewModel: ObservableObject {
+    /// Editable option used in the setup form.
+    struct EditableOption: Identifiable {
+        var id = UUID()
+        var text: String = ""
+    }
+
+    @Published var duration: Int = 60
+    @Published var allowsMultipleSelection = false
+    @Published var options: [EditableOption] = [EditableOption(), EditableOption()]
+    @Published var correctOptionIDs: Set<UUID> = []
+
+    var canStart: Bool {
+        duration > 0 && options.count >= 2 && !correctOptionIDs.isEmpty
+    }
+
+    func addOption() {
+        options.append(EditableOption())
+    }
+
+    func removeOption(id: UUID) {
+        options.removeAll { $0.id == id }
+        correctOptionIDs.remove(id)
+    }
+
+    func toggleCorrect(for id: UUID) {
+        if allowsMultipleSelection {
+            if correctOptionIDs.contains(id) { correctOptionIDs.remove(id) } else { correctOptionIDs.insert(id) }
+        } else {
+            correctOptionIDs = [id]
+        }
+    }
+
+    func start(interactionService: InteractionService) {
+        let question = MultipleChoiceQuestion(
+            options: options.map { .init(id: $0.id.uuidString, text: $0.text) },
+            correctOptionIDs: correctOptionIDs.map { $0.uuidString },
+            allowsMultipleSelection: allowsMultipleSelection
+        )
+        let request = InteractionRequest(
+            template: .floatingCorner,
+            lifecycle: .finite(seconds: duration),
+            content: .multipleChoice(question)
+        )
+        interactionService.startInteraction(request)
+    }
+}
+#endif

--- a/InteractiveClassroom/ViewModel/Client/Teacher/MultipleChoiceSetupViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Client/Teacher/MultipleChoiceSetupViewModel.swift
@@ -1,7 +1,9 @@
 #if os(iOS)
 import Foundation
+import Combine
 
 /// View model managing the creation of a multiple-choice interaction.
+@MainActor
 final class MultipleChoiceSetupViewModel: ObservableObject {
     /// Editable option used in the setup form.
     struct EditableOption: Identifiable {

--- a/InteractiveClassroom/ViewModel/Server/MultipleChoiceOverlayViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MultipleChoiceOverlayViewModel.swift
@@ -1,7 +1,9 @@
 #if os(macOS)
 import Foundation
+import Combine
 
 /// View model powering the multiple-choice overlay.
+@MainActor
 final class MultipleChoiceOverlayViewModel: ObservableObject {
     let question: MultipleChoiceQuestion
     /// Human-readable statistics for each option (e.g., "A: 50%").

--- a/InteractiveClassroom/ViewModel/Server/MultipleChoiceOverlayViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Server/MultipleChoiceOverlayViewModel.swift
@@ -1,0 +1,17 @@
+#if os(macOS)
+import Foundation
+
+/// View model powering the multiple-choice overlay.
+final class MultipleChoiceOverlayViewModel: ObservableObject {
+    let question: MultipleChoiceQuestion
+    /// Human-readable statistics for each option (e.g., "A: 50%").
+    @Published var stats: [String]
+    /// Names of participants who have submitted answers.
+    @Published var submittedNames: [String] = []
+
+    init(question: MultipleChoiceQuestion) {
+        self.question = question
+        self.stats = question.options.map { "\($0.text): 0%" }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- implement `MultipleChoiceQuestion` data model and networking payloads
- add macOS overlay views and view models for quiz statistics and submissions
- extend teacher client with quiz setup tab and view model
- support multiple-choice content in interaction request and service

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a4029d54088321b8f9b8258df6d042