### PR TITLE
Fix client-server clock desynchronization

### DIFF
--- a/InteractiveClassroom/Model/Interaction/CountdownService.swift
+++ b/InteractiveClassroom/Model/Interaction/CountdownService.swift
@@ -4,25 +4,38 @@ import Combine
 @MainActor
 final class CountdownService: ObservableObject {
     @Published private(set) var remainingSeconds: Int
-    private var task: Task<Void, Never>?
+    private var timer: AnyCancellable?
+    private var endDate: Date?
 
     init(seconds: Int) {
         self.remainingSeconds = max(0, seconds)
     }
 
     func start(onCompletion: @escaping @MainActor () -> Void) {
-        task?.cancel()
-        task = Task { @MainActor [weak self] in
-            while let self, self.remainingSeconds > 0 {
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-                self.remainingSeconds -= 1
-            }
+        stop()
+        guard remainingSeconds > 0 else {
             onCompletion()
+            return
         }
+        endDate = Date().addingTimeInterval(TimeInterval(remainingSeconds))
+        timer = Timer.publish(every: 1, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] now in
+                guard let self, let endDate else { return }
+                let newValue = max(0, Int(endDate.timeIntervalSince(now).rounded(.down)))
+                if newValue != self.remainingSeconds {
+                    self.remainingSeconds = newValue
+                }
+                if newValue == 0 {
+                    self.stop()
+                    onCompletion()
+                }
+            }
     }
 
     func stop() {
-        task?.cancel()
-        task = nil
+        timer?.cancel()
+        timer = nil
+        endDate = nil
     }
 }

--- a/InteractiveClassroom/Model/Interaction/InteractionService.swift
+++ b/InteractiveClassroom/Model/Interaction/InteractionService.swift
@@ -130,7 +130,8 @@ final class InteractionService: ObservableObject {
 
     // MARK: - Class Lifecycle
     func startClass(at startDate: Date) {
-        let seconds = max(0, Int(startDate.timeIntervalSinceNow))
+        let serverDate = startDate.addingTimeInterval(manager.timeOffset)
+        let seconds = max(0, Int(serverDate.timeIntervalSinceNow))
         let request = InteractionRequest(
             template: .fullScreen,
             lifecycle: .finite(seconds: seconds),
@@ -229,6 +230,10 @@ extension InteractionService: @preconcurrency InteractionHandling {
 
     func handleInteractionMessage(_ message: PeerConnectionManager.Message, from peerID: MCPeerID, session: MCSession) {
         switch message.type {
+        case "syncTime":
+            if let ts = message.timestamp {
+                manager.updateTimeOffset(with: ts)
+            }
         case "startClass":
             if let req = message.interaction {
                 startInteraction(req, broadcast: false)


### PR DESCRIPTION
## Summary
- add timestamp field to peer messages
- sync time offset from server and adjust class countdowns

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a426cf9d3c832190bfdf2b91ecb9f7