### PR TITLE
Add interaction status tab for teacher client

### DIFF
--- a/InteractiveClassroom/View/Client/Teacher/CustomTabView.swift
+++ b/InteractiveClassroom/View/Client/Teacher/CustomTabView.swift
@@ -3,46 +3,50 @@ import SwiftUI
 
 struct CustomTabView: View {
     let tabs: [TabItem]
+    let statusTab: TabItem
     @Binding var selection: Int
 
-    private var itemSize: CGFloat {
-        // Slightly smaller buttons for a lighter visual footprint
-        70
-    }
+    private var itemSize: CGFloat { 70 }
 
     var body: some View {
         let size = itemSize * 0.8
-        ScrollView(.horizontal, showsIndicators: false) {
-            // Wider gaps so tab items feel less cramped
-            HStack(spacing: size * 0.6) {
-                ForEach(Array(tabs.enumerated()), id: \.offset) { index, tab in
-                    Button(action: { selection = index }) {
-                        VStack(spacing: size * 0.1) {
-                            RoundedRectangle(cornerRadius: size * 0.25)
-                                .fill(selection == index ? Color.accentColor : Color.gray)
-                                .overlay(
-                                    Image(systemName: tab.icon)
-                                        .resizable()
-                                        .scaledToFit()
-                                        .foregroundColor(.white)
-                                        // Extra padding reduces the rendered SF Symbol size
-                                        .padding(size * 0.25)
-                                )
-                                .frame(width: size, height: size)
-                            Text(tab.title)
-                                .font(.system(size: size * 0.3))
-                                .foregroundColor(selection == index ? .primary : .secondary)
-                                .bold()
-                        }
-                        .frame(width: size * 1.3)
+        HStack(spacing: size * 0.6) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: size * 0.6) {
+                    ForEach(Array(tabs.enumerated()), id: \.offset) { index, tab in
+                        tabButton(tab, index: index, size: size)
                     }
-                    .buttonStyle(.plain)
                 }
+                .padding(.horizontal, size * 0.5)
+                .padding(.vertical, size * 0.4)
             }
-            .padding(.horizontal, size * 0.5)
-            .padding(.vertical, size * 0.4)
+            Spacer(minLength: size * 0.4)
+            tabButton(statusTab, index: tabs.count, size: size)
+                .padding(.trailing, size * 0.5)
         }
-//        .background(.ultraThinMaterial)
+    }
+
+    private func tabButton(_ tab: TabItem, index: Int, size: CGFloat) -> some View {
+        Button(action: { selection = index }) {
+            VStack(spacing: size * 0.1) {
+                RoundedRectangle(cornerRadius: size * 0.25)
+                    .fill(selection == index ? Color.accentColor : Color.gray)
+                    .overlay(
+                        Image(systemName: tab.icon)
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundColor(.white)
+                            .padding(size * 0.25)
+                    )
+                    .frame(width: size, height: size)
+                Text(tab.title)
+                    .font(.system(size: size * 0.3))
+                    .foregroundColor(selection == index ? .primary : .secondary)
+                    .bold()
+            }
+            .frame(width: size * 1.3)
+        }
+        .buttonStyle(.plain)
     }
 }
 
@@ -55,6 +59,7 @@ struct CustomTabView: View {
         TabItem(icon: "chart.bar.xaxis", title: "Reports"),
         TabItem(icon: "questionmark.circle", title: "Help")
     ]
-    return CustomTabView(tabs: demoTabs, selection: $selection)
+    let status = TabItem(icon: "waveform.path.ecg", title: "Status")
+    return CustomTabView(tabs: demoTabs, statusTab: status, selection: $selection)
 }
 #endif

--- a/InteractiveClassroom/View/Client/Teacher/InteractionStatusView.swift
+++ b/InteractiveClassroom/View/Client/Teacher/InteractionStatusView.swift
@@ -1,0 +1,28 @@
+#if os(iOS)
+import SwiftUI
+
+/// Displays the current interaction state and provides controls to stop it.
+struct InteractionStatusView: View {
+    @EnvironmentObject private var interactionService: InteractionService
+    @StateObject private var viewModel = InteractionStatusViewModel()
+    @ScaledMetric private var baseSpacing: CGFloat = 24
+
+    var body: some View {
+        VStack(spacing: baseSpacing) {
+            if let service = viewModel.countdownService,
+               viewModel.activeInteraction != nil {
+                TeacherCountdownView(service: service)
+                Button("Stop Interaction") {
+                    viewModel.stopCurrentInteraction()
+                }
+                .buttonStyle(.borderedProminent)
+            } else {
+                Text("No active interaction")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Status")
+        .onAppear { viewModel.bind(to: interactionService) }
+    }
+}
+#endif

--- a/InteractiveClassroom/View/Client/Teacher/MultipleChoiceSetupView.swift
+++ b/InteractiveClassroom/View/Client/Teacher/MultipleChoiceSetupView.swift
@@ -7,69 +7,56 @@ struct MultipleChoiceSetupView: View {
     @StateObject private var viewModel = MultipleChoiceSetupViewModel()
 
     var body: some View {
-        Group {
-            if let service = interactionService.countdownService,
-               interactionService.activeInteraction != nil {
-                VStack(spacing: 24) {
-                    TeacherCountdownView(service: service)
-                    Button("Stop Interaction") {
-                        interactionService.endInteraction()
-                    }
-                    .buttonStyle(.borderedProminent)
+        Form {
+            Section("Duration") {
+                Stepper(value: $viewModel.duration, in: 10...3600, step: 10) {
+                    Text("\(viewModel.duration) s")
                 }
-            } else {
-                Form {
-                    Section("Duration") {
-                        Stepper(value: $viewModel.duration, in: 10...3600, step: 10) {
-                            Text("\(viewModel.duration) s")
-                        }
-                    }
+            }
 
-                    Section("Options") {
-                        ForEach($viewModel.options) { $option in
-                            HStack {
-                                TextField("Option", text: $option.text)
-                                Button(role: .destructive) {
-                                    viewModel.removeOption(id: option.id)
-                                } label: {
-                                    Image(systemName: "minus.circle")
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                        Button {
-                            viewModel.addOption()
+            Section("Options") {
+                ForEach($viewModel.options) { $option in
+                    HStack {
+                        TextField("Option", text: $option.text)
+                        Button(role: .destructive) {
+                            viewModel.removeOption(id: option.id)
                         } label: {
-                            Label("Add Option", systemImage: "plus.circle")
+                            Image(systemName: "minus.circle")
                         }
-                    }
-
-                    Section("Answer") {
-                        Toggle("Allow multiple selection", isOn: $viewModel.allowsMultipleSelection)
-                        ForEach(viewModel.options) { option in
-                            Button {
-                                viewModel.toggleCorrect(for: option.id)
-                            } label: {
-                                HStack {
-                                    Text(option.text.isEmpty ? "Untitled" : option.text)
-                                    Spacer()
-                                    if viewModel.correctOptionIDs.contains(option.id) {
-                                        Image(systemName: "checkmark")
-                                            .foregroundColor(.accentColor)
-                                    }
-                                }
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-
-                    Section {
-                        Button("Start Interaction") {
-                            viewModel.start(interactionService: interactionService)
-                        }
-                        .disabled(!viewModel.canStart)
+                        .buttonStyle(.plain)
                     }
                 }
+                Button {
+                    viewModel.addOption()
+                } label: {
+                    Label("Add Option", systemImage: "plus.circle")
+                }
+            }
+
+            Section("Answer") {
+                Toggle("Allow multiple selection", isOn: $viewModel.allowsMultipleSelection)
+                ForEach(viewModel.options) { option in
+                    Button {
+                        viewModel.toggleCorrect(for: option.id)
+                    } label: {
+                        HStack {
+                            Text(option.text.isEmpty ? "Untitled" : option.text)
+                            Spacer()
+                            if viewModel.correctOptionIDs.contains(option.id) {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(.accentColor)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            Section {
+                Button("Start Interaction") {
+                    viewModel.start(interactionService: interactionService)
+                }
+                .disabled(!viewModel.canStart || interactionService.activeInteraction != nil)
             }
         }
         .navigationTitle("Quiz")

--- a/InteractiveClassroom/View/Client/Teacher/TeacherDashboardView.swift
+++ b/InteractiveClassroom/View/Client/Teacher/TeacherDashboardView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct TeacherDashboardView: View {
     @EnvironmentObject private var courseSessionService: CourseSessionService
     @EnvironmentObject private var pairingService: PairingService
+    @EnvironmentObject private var interactionService: InteractionService
     @StateObject private var viewModel = TeacherDashboardViewModel()
     @State private var selectedTab = 0
     @State private var showStartPopover = false
@@ -17,6 +18,9 @@ struct TeacherDashboardView: View {
         TabItem(icon: "list.bullet.rectangle", title: "Quiz")
     ]
 
+    private let statusTab = TabItem(icon: "waveform.path.ecg", title: "Status")
+    private var statusTabIndex: Int { tabs.count }
+
     var body: some View {
         VStack(spacing: 0) {
             TabView(selection: $selectedTab) {
@@ -26,10 +30,11 @@ struct TeacherDashboardView: View {
                 placeholder("Reports").tag(3)
                 placeholder("Help").tag(4)
                 MultipleChoiceSetupView().tag(5)
+                InteractionStatusView().tag(statusTabIndex)
             }
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
 
-            CustomTabView(tabs: tabs, selection: $selectedTab)
+            CustomTabView(tabs: tabs, statusTab: statusTab, selection: $selectedTab)
         }
         .navigationTitle("Teacher")
         .toolbar {
@@ -57,6 +62,11 @@ struct TeacherDashboardView: View {
             }
         }
         .onAppear { viewModel.bind(to: courseSessionService) }
+        .onReceive(interactionService.$activeInteraction) { interaction in
+            if interaction != nil {
+                selectedTab = statusTabIndex
+            }
+        }
     }
 
     private var studentsView: some View {

--- a/InteractiveClassroom/ViewModel/Client/Teacher/InteractionStatusViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Client/Teacher/InteractionStatusViewModel.swift
@@ -1,0 +1,32 @@
+#if os(iOS)
+import Foundation
+import Combine
+
+@MainActor
+final class InteractionStatusViewModel: ObservableObject {
+    @Published var countdownService: CountdownService?
+    @Published var activeInteraction: Interaction?
+
+    private var service: InteractionService?
+    private var cancellables = Set<AnyCancellable>()
+
+    func bind(to service: InteractionService) {
+        guard self.service == nil else { return }
+        self.service = service
+
+        service.$countdownService
+            .receive(on: RunLoop.main)
+            .assign(to: \.countdownService, on: self)
+            .store(in: &cancellables)
+
+        service.$activeInteraction
+            .receive(on: RunLoop.main)
+            .assign(to: \.activeInteraction, on: self)
+            .store(in: &cancellables)
+    }
+
+    func stopCurrentInteraction() {
+        service?.endInteraction()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add dedicated Interaction Status view and view model to monitor active interactions and stop them
- Refactor teacher dashboard to include always-visible status tab and auto-switch on interaction start
- Streamline quiz setup view and enhance custom tab view layout

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e23c7b88321953192f26272701a