### PR TITLE
Ensure overlay window activates app

### DIFF
--- a/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
+++ b/InteractiveClassroom/ViewModel/Server/OverlayWindowManager.swift
@@ -56,6 +56,7 @@ final class OverlayWindowManager: ObservableObject {
             let window = NSWindow(contentViewController: controller)
             self.configureOverlayWindow(window)
             window.orderFrontRegardless()
+            NSApp.activate(ignoringOtherApps: true)
             self.overlayWindow = window
         }
 


### PR DESCRIPTION
## Summary
- Activate the macOS application after presenting the overlay window so it appears above other full-screen apps

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a4713831948321bbead9ba1f360b1d