### PR TITLE
feat: add stage-based interactions

### DIFF
--- a/InteractiveClassroom/Model/Interaction/InteractionBroadcaster.swift
+++ b/InteractiveClassroom/Model/Interaction/InteractionBroadcaster.swift
@@ -4,12 +4,13 @@ import MultipeerConnectivity
 // MARK: - Broadcasting Helpers
 extension InteractionService {
     /// Sends a start interaction message to the server.
-    func broadcastStartInteraction(_ request: InteractionRequest, remainingSeconds: Int?) {
+    func broadcastStartInteraction(_ request: InteractionRequest, remainingSeconds: Int?, stageIndex: Int) {
         let remaining = remainingSeconds ?? currentRemainingSeconds()
         let message = PeerConnectionManager.Message(
             type: "startInteraction",
             interaction: request,
-            remainingSeconds: remaining
+            remainingSeconds: remaining,
+            stageIndex: stageIndex
         )
         manager.sendMessageToServer(message)
     }
@@ -19,5 +20,11 @@ extension InteractionService {
         let message = PeerConnectionManager.Message(type: "stopInteraction", interaction: nil)
         manager.sendMessageToServer(message)
         print("[InteractionService] Sent stop interaction message to server.")
+    }
+
+    /// Sends a next stage message to the server.
+    func broadcastNextStage(_ stageIndex: Int) {
+        let message = PeerConnectionManager.Message(type: "nextStage", interaction: nil, stageIndex: stageIndex)
+        manager.sendMessageToServer(message)
     }
 }

--- a/InteractiveClassroom/Model/Interaction/Stage.swift
+++ b/InteractiveClassroom/Model/Interaction/Stage.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Represents a single stage within an interaction.
+struct InteractionStage: Codable, Equatable, Identifiable {
+    /// Sequential identifier for ordering stages.
+    let id: Int
+    /// Content to present during this stage.
+    let content: InteractionRequest.Content
+}

--- a/InteractiveClassroom/Model/PeerConnection/PeerConnectionManager.swift
+++ b/InteractiveClassroom/Model/PeerConnection/PeerConnectionManager.swift
@@ -91,6 +91,8 @@ class PeerConnectionManager: NSObject, ObservableObject {
         let interaction: InteractionRequest?
         /// Remaining seconds for a running interaction when applicable
         let remainingSeconds: Int?
+        /// Current stage index for multi-stage interactions
+        let stageIndex: Int?
         /// Server timestamp included for time synchronization
         let timestamp: Date?
 
@@ -102,6 +104,7 @@ class PeerConnectionManager: NSObject, ObservableObject {
              lesson: LessonPayload? = nil,
              interaction: InteractionRequest? = nil,
              remainingSeconds: Int? = nil,
+             stageIndex: Int? = nil,
              timestamp: Date? = nil) {
             self.type = type
             self.role = role
@@ -111,6 +114,7 @@ class PeerConnectionManager: NSObject, ObservableObject {
             self.lesson = lesson
             self.interaction = interaction
             self.remainingSeconds = remainingSeconds
+            self.stageIndex = stageIndex
             self.timestamp = timestamp
         }
     }

--- a/InteractiveClassroom/View/Client/Teacher/InteractionStatusView.swift
+++ b/InteractiveClassroom/View/Client/Teacher/InteractionStatusView.swift
@@ -12,10 +12,20 @@ struct InteractionStatusView: View {
             if let service = viewModel.countdownService,
                viewModel.activeInteraction != nil {
                 TeacherCountdownView(service: service)
-                Button("Stop Interaction") {
-                    viewModel.stopCurrentInteraction()
+            }
+            if viewModel.activeInteraction != nil {
+                HStack(spacing: baseSpacing) {
+                    if viewModel.canAdvanceStage {
+                        Button("Next Stage") {
+                            viewModel.advanceStage()
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                    Button("Stop Interaction") {
+                        viewModel.stopCurrentInteraction()
+                    }
+                    .buttonStyle(.borderedProminent)
                 }
-                .buttonStyle(.borderedProminent)
             } else {
                 Text("No active interaction")
                     .foregroundStyle(.secondary)

--- a/InteractiveClassroom/ViewModel/Client/Teacher/MultipleChoiceSetupViewModel.swift
+++ b/InteractiveClassroom/ViewModel/Client/Teacher/MultipleChoiceSetupViewModel.swift
@@ -43,10 +43,12 @@ final class MultipleChoiceSetupViewModel: ObservableObject {
             correctOptionIDs: correctOptionIDs.map { $0.uuidString },
             allowsMultipleSelection: allowsMultipleSelection
         )
+        let summary = InteractionStage(id: 1, content: .text("Summary"))
         let request = InteractionRequest(
             template: .floatingCorner,
             lifecycle: .finite(seconds: duration),
-            content: .multipleChoice(question)
+            content: .multipleChoice(question),
+            stages: [summary]
         )
         interactionService.startInteraction(request)
     }


### PR DESCRIPTION
## Summary
- model stages within interactions and track current stage
- allow advancing stages and broadcasting stage changes
- expose Next Stage controls in teacher status view
- add summary stage placeholder to multiple-choice interactions

## Testing
- `xcodebuild -list -project InteractiveClassroom.xcodeproj` *(fails: command not found: xcodebuild)*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a48631b7088321a477da9a57d624b8